### PR TITLE
nose.tools now imports fail and fail_* methods from unittest.TestCase

### DIFF
--- a/nose/tools/trivial.py
+++ b/nose/tools/trivial.py
@@ -42,7 +42,7 @@ class Dummy(unittest.TestCase):
 _t = Dummy('nop')
 
 for at in [ at for at in dir(_t)
-            if at.startswith('assert') and not '_' in at ]:
+            if re.match(r'assert|fail([A-Z]|$)', at) and not '_' in at ]:
     pepd = pep8(at)
     vars()[pepd] = getattr(_t, at)
     __all__.append(pepd)

--- a/unit_tests/test_tools.py
+++ b/unit_tests/test_tools.py
@@ -5,6 +5,29 @@ from nose.tools import *
 
 compat_24 =  sys.version_info >= (2, 4)
 
+def test_imported_from_unittest_testcase():
+    expected_methods = ['assert_almost_equal', 'assert_almost_equals',
+        'assert_dict_contains_subset', 'assert_dict_equal', 'assert_equal',
+        'assert_equals', 'assert_false', 'assert_greater',
+        'assert_greater_equal', 'assert_in', 'assert_is', 'assert_is_instance',
+        'assert_is_none', 'assert_is_not', 'assert_is_not_none',
+        'assert_items_equal', 'assert_less', 'assert_less_equal',
+        'assert_list_equal', 'assert_multi_line_equal',
+        'assert_not_almost_equal', 'assert_not_almost_equals',
+        'assert_not_equal', 'assert_not_equals', 'assert_not_in',
+        'assert_not_is_instance', 'assert_not_regexp_matches', 'assert_raises',
+        'assert_raises_regexp', 'assert_regexp_matches',
+        'assert_sequence_equal', 'assert_set_equal', 'assert_true',
+        'assert_tuple_equal', 'fail', 'fail_if', 'fail_if_almost_equal',
+        'fail_if_equal', 'fail_unless', 'fail_unless_almost_equal',
+        'fail_unless_equal', 'fail_unless_raises']
+    for method in expected_methods:
+        yield check_method, method
+
+def check_method(n):
+    import nose.tools
+    assert n in dir(nose.tools)
+
 class TestTools(unittest.TestCase):
 
     def test_ok(self):


### PR DESCRIPTION
nose.tools now imports fail and fail_\* methods from unittest.TestCase
