### PR TITLE
Fix docs describing the arguments of formatFailure and formatError

### DIFF
--- a/nose/plugins/base.py
+++ b/nose/plugins/base.py
@@ -323,8 +323,8 @@ class IPluginInterface(object):
     def formatError(self, test, err):
         """Called in result.addError, before plugin.addError. If you
         want to replace or modify the error tuple, return a new error
-        tuple.
-
+        tuple, otherwise return err, the original error tuple.
+        
         :param test: the test case
         :type test: :class:`nose.case.Test`
         :param err: sys.exc_info() tuple
@@ -339,11 +339,8 @@ class IPluginInterface(object):
     def formatFailure(self, test, err):
         """Called in result.addFailure, before plugin.addFailure. If you
         want to replace or modify the error tuple, return a new error
-        tuple. Because this method is chainable, you must return the
-        test as well, so you'll return something like::
-
-          return (test, err)
-
+        tuple, otherwise return err, the original error tuple.
+        
         :param test: the test case
         :type test: :class:`nose.case.Test`
         :param err: sys.exc_info() tuple


### PR DESCRIPTION
As far as I can tell, based on reading the code of PluginProxy.chain(), the note about `return (test, err)` is simply wrong. Also, some plugin implementors, for example https://github.com/abeld/freshen/blob/master/freshen/noseplugin.py#L230 interpret the documentation as "I don't have to do anything, if I don't modify the error tuple", which I assume is also wrong, since the next formatError or formatFailure method in the chain will get None instead of the error tuple.
