### PR TITLE
add loglevel option to logcapture plugin and add associated test

### DIFF
--- a/nose/plugins/logcapture.py
+++ b/nose/plugins/logcapture.py
@@ -149,6 +149,10 @@ class LogCapture(Plugin):
             "--logging-clear-handlers", action="store_true",
             default=False, dest="logcapture_clear",
             help="Clear all other logging handlers")
+        parser.add_option(
+            "--logging-level", action="store",
+            default='NOTSET', dest="logcapture_level",
+            help="Set the log level to capture")
 
     def configure(self, options, conf):
         """Configure plugin.
@@ -161,6 +165,7 @@ class LogCapture(Plugin):
         self.logformat = options.logcapture_format
         self.logdatefmt = options.logcapture_datefmt
         self.clear = options.logcapture_clear
+        self.loglevel = options.logcapture_level
         if options.logcapture_filters:
             self.filters = options.logcapture_filters.split(',')
 
@@ -186,7 +191,8 @@ class LogCapture(Plugin):
                 root_logger.handlers.remove(handler)
         root_logger.addHandler(self.handler)
         # to make sure everything gets captured
-        root_logger.setLevel(logging.NOTSET)
+        loglevel = getattr(self, "loglevel", "NOTSET")
+        root_logger.setLevel(getattr(logging, loglevel))
 
     def begin(self):
         """Set up logging handler before test run begins.

--- a/unit_tests/test_logcapture_plugin.py
+++ b/unit_tests/test_logcapture_plugin.py
@@ -79,6 +79,22 @@ class TestLogCapturePlugin(object):
         eq_(1, len(c.handler.buffer))
         eq_("Hello", c.handler.buffer[0].msg)
 
+    def test_loglevel(self):
+        c = LogCapture()
+        parser = OptionParser()
+        c.addOptions(parser, {})
+        options, args = parser.parse_args(['--logging-level', 'INFO'])
+        c.configure(options, Config())
+        c.start()
+        log = logging.getLogger("loglevel")
+        log.debug("Hello")
+        log.info("Goodbye")
+        c.end()
+        records = c.formatLogRecords()
+        eq_(1, len(c.handler.buffer))
+        eq_("Goodbye", c.handler.buffer[0].msg)
+        eq_("loglevel: INFO: Goodbye", records[0])
+
     def test_clears_all_existing_log_handlers(self):
         c = LogCapture()
         parser = OptionParser()
@@ -101,7 +117,6 @@ class TestLogCapturePlugin(object):
         c.start()
         c.beforeTest(mktest())
         c.end()
-
 
         if py27:
             expect = ["<class 'nose.plugins.logcapture.MyMemoryHandler'>"]
@@ -141,7 +156,7 @@ class TestLogCapturePlugin(object):
         assert records[0].startswith('foo:'), records[0]
         assert records[1].startswith('foo.x:'), records[1]
         assert records[2].startswith('bar.quux:'), records[2]
-        
+
     def test_logging_filter_exclude(self):
         env = {'NOSE_LOGFILTER': '-foo,-bar'}
         c = LogCapture()
@@ -159,7 +174,7 @@ class TestLogCapturePlugin(object):
         eq_(2, len(records))
         assert records[0].startswith('foobar.something:'), records[0]
         assert records[1].startswith('abara:'), records[1]
-        
+
     def test_logging_filter_exclude_and_include(self):
         env = {'NOSE_LOGFILTER': 'foo,-foo.bar'}
         c = LogCapture()


### PR DESCRIPTION
The way logcapture currently sets the loglevel to NOTSET can make it pretty difficult to work with tests that are log verbose.

--logging-level is meant to set the loglevel to whatever is passed in as an argument. Setting loglevel to WARNING can be very helpful.

Closes #21. 
