### PR TITLE
Save result as instance attribute in TestProgram.

### DIFF
--- a/nose/core.py
+++ b/nose/core.py
@@ -194,8 +194,8 @@ class TestProgram(unittest.TestProgram):
         plug_runner = self.config.plugins.prepareTestRunner(self.testRunner)
         if plug_runner is not None:
             self.testRunner = plug_runner
-        result = self.testRunner.run(self.test)
-        self.success = result.wasSuccessful()
+        self.result = self.testRunner.run(self.test)
+        self.success = self.result.wasSuccessful()
         if self.exit:
             sys.exit(not self.success)
         return self.success


### PR DESCRIPTION
We need to save result as an instance attribute in TestProgramm to be able to compute result after execution.