### PR TITLE
Stop using the `assert` statement in `ok_` and `eq_` so they work under ...

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,8 +11,9 @@
 - Fixed Unicode issue on Python 3.1 with coverage (#442)
 - fixed class level fixture handling in multiprocessing plugin
 - Clue in the ``unittest`` module so it no longer prints traceback frames for
-  our clones of their simple assertion helpers. (#453).
-  Patch by Erik Rose.
+  our clones of their simple assertion helpers (#453). Patch by Erik Rose.
+- Stop using the ``assert`` statement in ``ok_`` and ``eq_`` so they work under
+  ``python -O`` (#504). Patch by Erik Rose.
 
 1.1.2
 

--- a/nose/tools/trivial.py
+++ b/nose/tools/trivial.py
@@ -18,13 +18,15 @@ __unittest = 1
 def ok_(expr, msg=None):
     """Shorthand for assert. Saves 3 whole characters!
     """
-    assert expr, msg
+    if not expr:
+        raise AssertionError(msg)
 
 
 def eq_(a, b, msg=None):
     """Shorthand for 'assert a == b, "%r != %r" % (a, b)
     """
-    assert a == b, msg or "%r != %r" % (a, b)
+    if not a == b:
+        raise AssertionError(msg or "%r != %r" % (a, b))
 
 
 #


### PR DESCRIPTION
...`python -O`. Closes #504.
