### PR TITLE
#301 - Call reactor.stop from twisted thread.

### DIFF
--- a/nose/twistedtools.py
+++ b/nose/twistedtools.py
@@ -75,6 +75,7 @@ def stop_reactor():
         '''Helper for calling stop from withing the thread.'''
         reactor.stop()
 
+    reactor.callFromThread(stop_reactor)
     reactor_thread.join()
     for p in reactor.getDelayedCalls():
         if p.active():


### PR DESCRIPTION
This is a fix for bug #301.

Since all Twisted code is executed in a twisted thread, stop should also be called from the thread.
