### PR TITLE
Suppress tracebacks caused by ConfigErrors

### DIFF
--- a/functional_tests/doc_tests/test_restricted_plugin_options/restricted_plugin_options.rst
+++ b/functional_tests/doc_tests/test_restricted_plugin_options/restricted_plugin_options.rst
@@ -50,7 +50,7 @@ plugins implementing `startTest`, an exception is raised and nose exits.
     >>> run(argv=argv, plugins=restricted) #doctest: +REPORT_NDIFF +ELLIPSIS
     Traceback (most recent call last):
     ...
-    SystemExit: ...
+    SystemExit: 2
 
 Errors are only raised when options defined by excluded plugins are used.
 
@@ -86,4 +86,4 @@ error is raised.
     >>> run(argv=argv, plugins=restricted) # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    ConfigError: Error reading config file '...bad.cfg': no such option 'with-meltedcheese'
+    SystemExit: 2

--- a/nose/config.py
+++ b/nose/config.py
@@ -129,7 +129,10 @@ class ConfiguredDefaultsOptionParser(object):
         except ConfigError, exc:
             self._error(str(exc))
         else:
-            self._applyConfigurationToValues(self._parser, config, values)
+            try:
+                self._applyConfigurationToValues(self._parser, config, values)
+            except ConfigError, exc:
+                self._error(str(exc))
         return self._parser.parse_args(args, values)
 
 


### PR DESCRIPTION
Show a kind error message instead of a traceback
when an unknown configuration variable is found in
a file.

This is a fix for issue #401
