### PR TITLE
Update nose/core.py

### DIFF
--- a/nose/core.py
+++ b/nose/core.py
@@ -16,6 +16,8 @@ from nose.result import TextTestResult
 from nose.suite import FinalizingSuiteWrapper
 from nose.util import isclass, tolist
 
+# added to disable reading/writing of python bytecode
+sys.dont_write_bytecode = True
 
 log = logging.getLogger('nose.core')
 compat_24 = sys.version_info >= (2, 4)


### PR DESCRIPTION
added "sys.dont_write_bytecode = True" to disable reading/writing of python bytecode in tests.

i realize there should be a configurable option for this, but recommending that it be taken into consideration.
