### PR TITLE
Use `nose.__loader__` to load 'usage.txt', if available.

### DIFF
--- a/nose/core.py
+++ b/nose/core.py
@@ -237,14 +237,21 @@ class TestProgram(unittest.TestProgram):
 
     def usage(cls):
         import nose
-        if hasattr(nose, '__loader__'):
+        try:
             ld = nose.__loader__
-            if hasattr(ld, 'zipfile'):
-                # nose was imported from a zipfile
-                return ld.get_data(
-                        os.path.join(ld.prefix, 'nose', 'usage.txt'))
-        return open(os.path.join(
-                os.path.dirname(__file__), 'usage.txt'), 'r').read()
+            text = ld.get_data(os.path.join(
+                os.path.dirname(__file__), 'usage.txt'))
+        except AttributeError:
+            f = open(os.path.join(
+                os.path.dirname(__file__), 'usage.txt'), 'r')
+            try:
+                text = f.read()
+            finally:
+                f.close()
+        # Ensure that we return str, not bytes.
+        if not isinstance(text, str):
+            text = text.decode('utf-8')
+        return text
     usage = classmethod(usage)
 
 # backwards compatibility

--- a/unit_tests/test_core.py
+++ b/unit_tests/test_core.py
@@ -33,64 +33,36 @@ class Undefined(object):
     pass
 
 class TestUsage(unittest.TestCase):
-    
+
     def test_from_directory(self):
         usage_txt = nose.core.TestProgram.usage()
         assert usage_txt.startswith('nose collects tests automatically'), (
                 "Unexpected usage: '%s...'" % usage_txt[0:50].replace("\n", '\n'))
-    
+
     def test_from_zip(self):
         requested_data = []
-        
+
         # simulates importing nose from a zip archive
         # with a zipimport.zipimporter instance
         class fake_zipimporter(object):
-            
-            prefix = ''
-            zipfile = '<fake zipfile>'
-            
+
             def get_data(self, path):
                 requested_data.append(path)
-                return "<usage>"
-                    
+                # Return as str in Python 2, bytes in Python 3.
+                return '<usage>'.encode('utf-8')
+
         existing_loader = getattr(nose, '__loader__', Undefined)
         try:
             nose.__loader__ = fake_zipimporter()
             usage_txt = nose.core.TestProgram.usage()
             self.assertEqual(usage_txt, '<usage>')
-            self.assertEqual(requested_data, ['nose%susage.txt' % os.sep])
+            self.assertEqual(requested_data, [os.path.join(
+                os.path.dirname(nose.__file__), 'usage.txt')])
         finally:
             if existing_loader is not Undefined:
                 nose.__loader__ = existing_loader
             else:
                 del nose.__loader__
-    
-    def test_from_zip_with_prefix(self):
-        requested_data = []
-        
-        # simulates importing nose from a zip archive
-        # with a zipimport.zipimporter instance
-        class fake_zipimporter(object):
-            
-            prefix = 'PREFIX'
-            zipfile = '<fake zipfile>'
-            
-            def get_data(self, path):
-                requested_data.append(path)
-                return "<usage>"
-                
-        existing_loader = getattr(nose, '__loader__', Undefined)
-        try:            
-            nose.__loader__ = fake_zipimporter()
-            usage_txt = nose.core.TestProgram.usage()
-            self.assertEqual(usage_txt, '<usage>')
-            self.assertEqual(requested_data, 
-                             ['PREFIX%snose%susage.txt' % (os.sep, os.sep)])
-        finally:
-            if existing_loader is not Undefined:
-                nose.__loader__ = existing_loader
-            else:
-                del nose.__loader__
-        
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously we only used `nose.__loader__` if we thought that the loader was zipimporter. Additionally, we use `nose.__file__` to build the path to 'usage.txt' as suggested by [PEP-302](http://www.python.org/dev/peps/pep-0302/#optional-extensions-to-the-importer-protocol).
