### PR TITLE
Skip `__pycache__` directories in `ls_tree`.

### DIFF
--- a/nose/util.py
+++ b/nose/util.py
@@ -20,7 +20,7 @@ log = logging.getLogger('nose')
 
 ident_re = re.compile(r'^[A-Za-z_][A-Za-z0-9_.]*$')
 class_types = (ClassType, TypeType)
-skip_pattern = r"(?:\.svn)|(?:[^.]+\.py[co])|(?:.*~)|(?:.*\$py\.class)"
+skip_pattern = r"(?:\.svn)|(?:[^.]+\.py[co])|(?:.*~)|(?:.*\$py\.class)|(?:__pycache__)"
 
 try:
     set()


### PR DESCRIPTION
Closes #519, which reported:

```
----------------------------------------------------------------------
File "/home/unix/aksarkar/.local/src/nose/build/tests/functional_tests/doc_tests/test_selector_plugin/selector_plugin.rst", line 22, in selector_plugin.rst
Failed example:
    print(ls_tree(support))
Expected:
    |-- mymodule.py
    |-- mypackage
    |   |-- __init__.py
    |   |-- strings.py
    |   `-- math
    |       |-- __init__.py
    |       `-- basic.py
    `-- tests
        |-- testlib.py
        |-- math
        |   `-- basic.py
        |-- mymodule
        |   `-- my_function.py
        `-- strings
            `-- cat.py
Got:
    |-- mymodule.py
    |-- __pycache__
    |   `-- mymodule.cpython-32.pyc
    |-- mypackage
    |   |-- __init__.py
    |   |-- strings.py
    |   |-- __pycache__
    |   |   |-- __init__.cpython-32.pyc
    |   |   `-- strings.cpython-32.pyc
    |   `-- math
    |       |-- __init__.py
    |       |-- basic.py
    |       `-- __pycache__
    |           |-- __init__.cpython-32.pyc
    |           `-- basic.cpython-32.pyc
    `-- tests
        |-- testlib.py
        |-- __pycache__
        |   `-- testlib.cpython-32.pyc
        |-- math
        |   |-- basic.py
        |   `-- __pycache__
        |       `-- basic.cpython-32.pyc
        |-- mymodule
        |   |-- my_function.py
        |   `-- __pycache__
        |       `-- my_function.cpython-32.pyc
        `-- strings
            |-- cat.py
            `-- __pycache__
                `-- cat.cpython-32.pyc


----------------------------------------------------------------------
```
