### PR TITLE
Adds support for nose to be called with a verbose test name.

### DIFF
--- a/functional_tests/test_selector.py
+++ b/functional_tests/test_selector.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from nose.selector import Selector, TestAddress
+from nose.selector import TestAddress
 
 support = os.path.abspath(os.path.join(os.path.dirname(__file__), 'support'))
 
@@ -11,6 +11,19 @@ class TestTestAddress(unittest.TestCase):
         addr = TestAddress('test_pak.test_mod', workingDir=wd)
         self.assertEqual(addr.filename,
                          os.path.join(wd, 'test_pak', 'test_mod.py'))
+
+    def test_test_verbose_name_function(self):
+        wd = os.path.join(support, 'package2')
+        addr = TestAddress('test_pak.test_mod.test_add', workingDir=wd)
+        self.assertEqual(addr.filename,
+                         os.path.join(wd, 'test_pak', 'test_mod.py'))
+        self.assertEqual(addr.call, 'test_add')
+
+    def test_test_verbose_name_method(self):
+        wd = os.path.join(support, 'att')
+        addr = TestAddress('test_attr.TestClass.test_class_one', workingDir=wd)
+        self.assertEqual(addr.filename, os.path.join(wd, 'test_attr.py'))
+        self.assertEqual(addr.call, 'TestClass.test_class_one')
 
 
 if __name__ == '__main__':

--- a/nose/selector.py
+++ b/nose/selector.py
@@ -223,7 +223,8 @@ class TestAddress(object):
             workingDir = os.getcwd()
         self.name = name
         self.workingDir = workingDir
-        self.filename, self.module, self.call = split_test_name(name)
+        self.filename, self.module, self.call = split_test_name(
+            name, workingDir)
         log.debug('Test name %s resolved to file %s, module %s, call %s',
                   name, self.filename, self.module, self.call)
         if self.filename is None:

--- a/nose/util.py
+++ b/nose/util.py
@@ -332,7 +332,22 @@ def resolve_name(name, module=None):
     return obj
 
 
-def split_test_name(test):
+def split_verbose_test_name(verbose_test_name, workingDir):
+    """Split a verbose test name into a filename and a callable."""
+    file_parts = verbose_test_name.split('.')[:-1]
+    test_parts = [verbose_test_name.split('.')[-1]]
+    while len(file_parts) > 0:
+        module_path = os.sep.join(file_parts) + '.py'
+        if os.path.exists(os.path.join(workingDir, module_path)):
+            break
+        test_parts.insert(0, file_parts.pop())
+    if not file_parts:
+        return (None, verbose_test_name)
+    test_name = '.'.join(test_parts)
+    return (module_path, test_name)
+
+
+def split_test_name(test, workingDir):
     """Split a test name into a 3-tuple containing file, module, and callable
     names, any of which (but not all) may be blank.
 
@@ -350,8 +365,10 @@ def split_test_name(test):
         # only a file or mod part
         if file_like(test):
             return (norm(test), None, None)
-        else:
-            return (None, test, None)
+        file_name, test_name = split_verbose_test_name(test, workingDir)
+        if file_name:
+            return (file_name, None, test_name)
+        return (None, test, None)
 
     # could be path|mod:callable, or a : in the file path someplace
     head, tail = os.path.split(test)

--- a/nose/util.py
+++ b/nose/util.py
@@ -347,7 +347,7 @@ def split_verbose_test_name(verbose_test_name, workingDir):
     return (module_path, test_name)
 
 
-def split_test_name(test, workingDir):
+def split_test_name(test, workingDir=None):
     """Split a test name into a 3-tuple containing file, module, and callable
     names, any of which (but not all) may be blank.
 
@@ -365,9 +365,10 @@ def split_test_name(test, workingDir):
         # only a file or mod part
         if file_like(test):
             return (norm(test), None, None)
-        file_name, test_name = split_verbose_test_name(test, workingDir)
-        if file_name:
-            return (file_name, None, test_name)
+        if workingDir:
+            file_name, test_name = split_verbose_test_name(test, workingDir)
+            if file_name:
+                return (file_name, None, test_name)
         return (None, test, None)
 
     # could be path|mod:callable, or a : in the file path someplace


### PR DESCRIPTION
This makes it more convenient to re-run a failed test as one can simply
copy/paste the output of nose.
