### PR TITLE
Fix for issue #554, nose.test not being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ try:
 except ImportError:
     from distutils.core import setup
     addl_args = dict(
-        packages = ['nose', 'nose.ext', 'nose.plugins', 'nose.sphinx'],
+        packages = ['nose', 'nose.ext', 'nose.plugins', 'nose.sphinx',
+                    'nose.test'],
         scripts = ['bin/nosetests'],
         )
 


### PR DESCRIPTION
This pull request fixes issue #554 using the fix I suggested on the issue (but with line wrapping to avoid exceeding 80 characters).
