### PR TITLE
Fix for issue #554, nose.tools not being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ try:
 except ImportError:
     from distutils.core import setup
     addl_args = dict(
-        packages = ['nose', 'nose.ext', 'nose.plugins', 'nose.sphinx'],
+        packages = ['nose', 'nose.ext', 'nose.plugins', 'nose.sphinx',
+                    'nose.test'],
         scripts = ['bin/nosetests'],
         )
 


### PR DESCRIPTION
Replaces https://github.com/nose-devs/nose/pull/576 where I managed to mix up tools and test.
