### PR TITLE
Stop forgetting to install package 'nose.tools'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ try:
 except ImportError:
     from distutils.core import setup
     addl_args = dict(
-        packages = ['nose', 'nose.ext', 'nose.plugins', 'nose.sphinx'],
+        packages = ['nose', 'nose.ext', 'nose.plugins', 'nose.sphinx',
+                    'nose.tools'],
         scripts = ['bin/nosetests'],
         )
 


### PR DESCRIPTION
Generally this isn't a problem as setuptools will correctly provide the list of packages to install:

```
$ python
Python 2.7.3 (default, Aug  1 2012, 05:14:39) 
[GCC 4.6.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from setuptools import find_packages
>>> find_packages()
['nose', 'nose.sphinx', 'nose.plugins', 'nose.tools', 'nose.ext']
```

This fixes the installation for the (rare) case when setuptools is not importable.
