### PR TITLE
Fix: missing method on test class from another module raises Error

### DIFF
--- a/nose/loader.py
+++ b/nose/loader.py
@@ -385,7 +385,8 @@ class TestLoader(unittest.TestLoader):
                 name = addr.call
             parent, obj = self.resolve(name, module)
             if (isclass(parent)
-                and getattr(parent, '__module__', None) != module.__name__):
+                and getattr(parent, '__module__', None) != module.__name__
+                and not isinstance(obj, Failure)):
                 parent = transplant_class(parent, module.__name__)
                 obj = getattr(parent, obj.__name__)
             log.debug("parent %s obj %s module %s", parent, obj, module)


### PR DESCRIPTION
This is a fix for the following issue:

Attempting to run a non-existent method on a test class that has been imported from another module results in an ugly error. For instance:

```
$ _virtualenv/bin/nosetests tests/remote_tests.py:RemoteTests.can_restart_vm -v
Traceback (most recent call last):
  File "_virtualenv/bin/nosetests", line 9, in <module>
    load_entry_point('nose==1.2.1', 'console_scripts', 'nosetests')()
  File "/home/mick/Programming/current/peachtree/_virtualenv/src/nose/nose/core.py", line 118, in __init__
    **extra_args)
  File "/usr/lib/python2.7/unittest/main.py", line 94, in __init__
    self.parseArgs(argv)
  File "/home/mick/Programming/current/peachtree/_virtualenv/src/nose/nose/core.py", line 169, in parseArgs
    self.createTests()
  File "/home/mick/Programming/current/peachtree/_virtualenv/src/nose/nose/core.py", line 183, in createTests
    self.test = self.testLoader.loadTestsFromNames(self.testNames)
  File "/home/mick/Programming/current/peachtree/_virtualenv/src/nose/nose/loader.py", line 475, in loadTestsFromNames
    return unittest.TestLoader.loadTestsFromNames(self, names, module)
  File "/usr/lib/python2.7/unittest/loader.py", line 128, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/home/mick/Programming/current/peachtree/_virtualenv/src/nose/nose/loader.py", line 423, in loadTestsFromName
    return self.loadTestsFromName(addr.call, module)
  File "/home/mick/Programming/current/peachtree/_virtualenv/src/nose/nose/loader.py", line 390, in loadTestsFromName
    obj = getattr(parent, obj.__name__)
AttributeError: 'Failure' object has no attribute '__name__'
```

Whereas the expected output is:

```
$ _virtualenv/bin/nosetests tests/remote_tests.py:RemoteTests.can_restart_vm -v
Failure: ValueError (No such test RemoteTests.can_restart_vm) ... ERROR

======================================================================
ERROR: Failure: ValueError (No such test RemoteTests.can_restart_vm)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/mick/Programming/current/peachtree/_virtualenv/src/nose/nose/failure.py", line 39, in runTest
    raise self.exc_class(self.exc_val)
ValueError: No such test RemoteTests.can_restart_vm

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
```
