### PR TITLE
Add a way to manually designate a test generator

### DIFF
--- a/nose/tools/trivial.py
+++ b/nose/tools/trivial.py
@@ -9,7 +9,7 @@ import re
 import unittest
 
 
-__all__ = ['ok_', 'eq_']
+__all__ = ['ok_', 'eq_', 'test_generator']
 
 # Use the same flag as unittest itself to prevent descent into these functions:
 __unittest = 1
@@ -52,3 +52,15 @@ for at in [ at for at in dir(_t)
 del Dummy
 del _t
 del pep8
+
+#
+# Enable manual designation of a function as a test generator. Functions
+# which delegate test generation to others (applying another decorator
+# would have that effect, for example) are obviously not considered
+# generator functions by Python's introspection mechanisms.
+#
+def test_generator(func):
+    """Mark a function as a test generator.
+    """
+    func.__test_generator__ = True
+    return func

--- a/nose/util.py
+++ b/nose/util.py
@@ -170,7 +170,8 @@ def isclass(obj):
 
 def isgenerator(func):
     try:
-        return func.func_code.co_flags & CO_GENERATOR != 0
+        return (func.__code__.co_flags & CO_GENERATOR != 0) \
+            or getattr(func, "__test_generator__", False)
     except AttributeError:
         return False
 # backwards compat (issue #64)


### PR DESCRIPTION
Sometimes one cannot rely on Python's introspection mechanism to detect test generators. This notably happens when using patch decorators in the mock library. The problem is also described here: http://code.google.com/p/mock/issues/detail?id=172.

The proposed solution is to add a test_generator decorator function which attaches a magic `__test_generator__` attribute to its target, and check for it in `nose.util.isgenerator()`. The issue above can then be resolved like this:

``` python
@nose.tools.test_generator
@mock.patch("useless_module.SomeClass")
def test_method(self, mock_someclass):
    for i in range(3):
        result = i * 3
        yield self.check_call, i, result
```

This is admittedly less than elegant, but I can't think of anything else that would be reliable in this respect.
