### PR TITLE
Timed decorator doesn't return wrapped function result

### DIFF
--- a/nose/tools/nontrivial.py
+++ b/nose/tools/nontrivial.py
@@ -80,7 +80,7 @@ def set_trace():
     stdout = sys.stdout
     sys.stdout = sys.__stdout__
     pdb.Pdb().set_trace(sys._getframe().f_back)
-    
+
 
 def timed(limit):
     """Test must finish within specified time limit to pass.
@@ -94,10 +94,11 @@ def timed(limit):
     def decorate(func):
         def newfunc(*arg, **kw):
             start = time.time()
-            func(*arg, **kw)
+            result = func(*arg, **kw)
             end = time.time()
             if end - start > limit:
                 raise TimeExpired("Time limit (%s) exceeded" % limit)
+            return result
         newfunc = make_decorator(func)(newfunc)
         return newfunc
     return decorate

--- a/unit_tests/test_tools.py
+++ b/unit_tests/test_tools.py
@@ -88,6 +88,12 @@ class TestTools(unittest.TestCase):
             time.sleep(.1)
         quick = timed(.2)(quick)
 
+        def check_result():
+            return 42
+        check_result = timed(.2)(check_result)
+
+        assert 42 == check_result()
+
         quick()
         try:
             too_slow()


### PR DESCRIPTION
The timed decorator should return the result of the function it wraps, but it provides None thus breaking functionality.

This type of code breaks: 
http://stackoverflow.com/questions/14389154/timed-nose-tests-not-failing-properly/14390409#14390409
