### PR TITLE
Fix formatFailure expection if missing tb in exc_info

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Peter Bengtsson
 Gary Donovan
 Brendan McCollam
 Erik Rose
+Sascha Peilicke

--- a/nose/plugins/failuredetail.py
+++ b/nose/plugins/failuredetail.py
@@ -38,6 +38,10 @@ class FailureDetail(Plugin):
         """Add detail from traceback inspection to error message of a failure.
         """
         ec, ev, tb = err
-        tbinfo = inspect_traceback(tb)
+        tbinfo, str_ev = None, str(ev)
+        if tb:
+            tbinfo = inspect_traceback(tb)
+            str_ev = '\n'.join([str(ev), tbinfo])
         test.tbinfo = tbinfo
-        return (ec, '\n'.join([str(ev), tbinfo]), tb)
+        return (ec, str_ev, tb)
+

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -14,6 +14,7 @@ from nose.plugins.attrib import AttributeSelector
 from nose.plugins.base import Plugin
 from nose.plugins.cover import Coverage
 from nose.plugins.doctests import Doctest
+from nose.plugins.failuredetail import FailureDetail
 from nose.plugins.prof import Profile
 
 from mock import *
@@ -351,6 +352,28 @@ class TestAttribPlugin(unittest.TestCase):
         assert not plug.wantFunction(f3)
         assert not plug.wantFunction(f4)
         
+
+class TestFailureDetailPlugin(unittest.TestCase):
+
+    def test_formatFailure(self):
+        class DummyError(Exception):
+            pass
+
+        try:
+            raise DummyError
+        except DummyError:
+            exc_info = sys.exc_info()
+
+        plug = FailureDetail()
+        (ec, ev, tb) = plug.formatFailure(self, exc_info)
+        assert exc_info[0] is ec
+        assert exc_info[2] is tb
+        assert self.tbinfo is not None
+
+        exc_info = (exc_info[0], exc_info[1], None) # Try without traceback
+        (ec, ev, tb) = plug.formatFailure(self, exc_info)
+        assert self.tbinfo is None
+
 
 class TestProfPlugin(unittest.TestCase):
 


### PR DESCRIPTION
The FailureDetail plugin should not fail in formatFailure if no
traceback is in the exc_info tupple ('err' parameter). This happens,
e.g. when used with testtools:

Traceback (most recent call last):
  File "/usr/lib64/python2.6/site-packages/nose/case.py", line 133, in run
    self.runTest(result)
  File "/usr/lib64/python2.6/site-packages/nose/case.py", line 151, in runTest
    test(result)
  File "/usr/lib64/python2.6/unittest.py", line 300, in **call**
    return self.run(_args, *_kwds)
  File "/usr/lib64/python2.6/site-packages/testtools/testcase.py", line 518, in run
    return self.**RunTest(self, self.exception_handlers).run(result)
  File "/usr/lib64/python2.6/site-packages/testtools/runtest.py", line 74, in run
    return self._run_one(actual_result)
  File "/usr/lib64/python2.6/site-packages/testtools/runtest.py", line 88, in _run_one
    return self._run_prepared_result(ExtendedToOriginalDecorator(result))
  File "/usr/lib64/python2.6/site-packages/testtools/runtest.py", line 107, in _run_prepared_result
    handler(self.case, self.result, e)
  File "/usr/lib64/python2.6/site-packages/testtools/testcase.py", line 494, in _report_failure
    result.addFailure(self, details=self.getDetails())
  File "/usr/lib64/python2.6/site-packages/testtools/testresult/real.py", line 605, in addFailure
    return self.decorated.addFailure(test, err)
  File "/usr/lib64/python2.6/site-packages/nose/proxy.py", line 146, in addFailure
    formatted = plugins.formatFailure(self.test, err)
  File "/usr/lib64/python2.6/site-packages/nose/plugins/manager.py", line 99, in __call**
    return self.call(_arg, *_kw)
  File "/usr/lib64/python2.6/site-packages/nose/plugins/manager.py", line 141, in chain
    result = meth(_arg, *_kw)
  File "/usr/lib64/python2.6/site-packages/nose/plugins/failuredetail.py", line 41, in formatFailure
    tbinfo = inspect_traceback(tb)
  File "/usr/lib64/python2.6/site-packages/nose/inspector.py", line 26, in inspect_traceback
    while tb.tb_next:
AttributeError: 'NoneType' object has no attribute 'tb_next'
