### PR TITLE
Disable a timing test under PyPy.

### DIFF
--- a/functional_tests/test_multiprocessing/test_concurrent_shared.py
+++ b/functional_tests/test_multiprocessing/test_concurrent_shared.py
@@ -1,11 +1,21 @@
 import os
+import sys
+import unittest
 
 from test_multiprocessing import MPTestBase
+
+
+is_pypy = '__pypy__' in sys.builtin_module_names
+
 
 class TestConcurrentShared(MPTestBase):
     processes = 2
     suitepath = os.path.join(os.path.dirname(__file__), 'support',
                              'concurrent_shared')
+
+    def setUp(self):
+        if is_pypy:
+            raise unittest.SkipTest('pypy warm-up is too slow; skipping')
 
     def runTest(self):
         assert 'Ran 2 tests in 1.' in self.output, "make sure two tests use 1.x seconds (no more than 2 seconsd)"


### PR DESCRIPTION
The warm-up time is just too long.
