### PR TITLE
also capture stderr in capture plugin

### DIFF
--- a/unit_tests/test_capture_plugin.py
+++ b/unit_tests/test_capture_plugin.py
@@ -53,14 +53,14 @@ class TestCapturePlugin(unittest.TestCase):
         c.start()
         print "Hello"
         c.end()
-        self.assertEqual(c.buffer, "Hello\n")
+        self.assertEqual(c.stdout_buffer, "Hello\n")
         
     def test_captures_nonascii_stdout(self):
         c = Capture()
         c.start()
         print "test 日本"
         c.end()
-        self.assertEqual(c.buffer, "test 日本\n")
+        self.assertEqual(c.stdout_buffer, "test 日本\n")
 
     def test_format_error(self):
         class Dummy:


### PR DESCRIPTION
This change adds the option --capture-stderr which allows to also capture stderr with nose. In case of a failed test the captured stderr will be shown below the captured stdout.

This has also been requested here https://github.com/nose-devs/nose/issues/305

It might be possible to make the code more elegant but I'm not sure about the original intentions of the current code so I didn't do any refactoring.
