### PR TITLE
Issue #501: Make test generators importable in other modules

### DIFF
--- a/nose/loader.py
+++ b/nose/loader.py
@@ -575,9 +575,10 @@ class TestLoader(unittest.TestLoader):
                 else:
                     return MethodTestCase(obj)
         elif isfunction(obj):
+            isgen = isgenerator(obj)
             if parent and obj.__module__ != parent.__name__:
                 obj = transplant_func(obj, parent.__name__)
-            if isgenerator(obj):
+            if isgen:
                 return self.loadTestsFromGenerator(obj, parent)
             else:
                 return FunctionTestCase(obj)


### PR DESCRIPTION
Building a test factory using test generators won't work if the factory itself is imported and used in other modules.

This issue is fully described in the issue #501.

I saw there's no test explicitly covering the part which decorates the test case using `transplant_func`. Is it worth adding such a test?
