### PR TITLE
test_concurrent_shared.py: fixed a minor typo (seconsd -> seconds)

### DIFF
--- a/functional_tests/test_multiprocessing/test_concurrent_shared.py
+++ b/functional_tests/test_multiprocessing/test_concurrent_shared.py
@@ -22,7 +22,7 @@ class TestConcurrentShared(MPTestBase):
         MPTestBase.setUp(self)
 
     def runTest(self):
-        assert 'Ran 2 tests in 1.' in self.output, "make sure two tests use 1.x seconds (no more than 2 seconsd)"
+        assert 'Ran 2 tests in 1.' in self.output, "make sure two tests use 1.x seconds (no more than 2 seconds)"
         assert str(self.output).strip().endswith('OK')
 
 


### PR DESCRIPTION
A minor typo fix that has been bothering me since the first time I looked at that file. Not necessarily targetted at 1.3.
