### PR TITLE
Fix --cover-min-percentage with --cover-branches

### DIFF
--- a/nose/plugins/cover.py
+++ b/nose/plugins/cover.py
@@ -115,10 +115,10 @@ class Coverage(Plugin):
         self.coverPackages = []
         if options.cover_packages:
             if isinstance(options.cover_packages, (list, tuple)):
-                cover_packages = options.cover_packages                
+                cover_packages = options.cover_packages
             else:
                 cover_packages = [options.cover_packages]
-            for pkgs in [tolist(x) for x in cover_packages]:            
+            for pkgs in [tolist(x) for x in cover_packages]:
                 self.coverPackages.extend(pkgs)
         self.coverInclusive = options.cover_inclusive
         if self.coverPackages:
@@ -178,7 +178,7 @@ class Coverage(Plugin):
         if self.coverMinPercentage:
             f = StringIO.StringIO()
             self.coverInstance.report(modules, file=f)
-            m = re.search(r'-------\s\w+\s+\d+\s+\d+\s+(\d+)%\s+\d*\s{0,1}$', f.getvalue())
+            m = re.search(r'-------\s\w+\s+\d+\s+\d+(?:\s+\d+\s+\d+)?\s+(\d+)%\s+\d*\s{0,1}$', f.getvalue())
             if m:
                 percentage = int(m.groups()[0])
                 if percentage < self.coverMinPercentage:


### PR DESCRIPTION
When using the `--cover-min-percentage` option, the regex responsible
for extracting the cover percentage fails due to extra columns in the
result text when the `--cover-branches` option is also specified.

Using an optional (and non-capturing) group within the regex, we can
recognize a match whether or not the extra columns are present. This
fixes #626.

Note: The two other lines modified in this commit have only had the
trailing whitespace on the line removed.
