### PR TITLE
fake stdout should always have encoding attribute

### DIFF
--- a/nose/plugins/capture.py
+++ b/nose/plugins/capture.py
@@ -109,6 +109,8 @@ class Capture(Plugin):
     def start(self):
         self.stdout.append(sys.stdout)
         self._buf = StringIO()
+        if not hasattr(self._buf, 'encoding'):
+            self._buf.encoding = sys.__stdout__.encoding
         sys.stdout = self._buf
 
     def end(self):

--- a/unit_tests/test_capture_plugin.py
+++ b/unit_tests/test_capture_plugin.py
@@ -96,5 +96,12 @@ class TestCapturePlugin(unittest.TestCase):
             err = sys.exc_info()
         formatted = c.formatError(d, err)
 
+    def test_captured_stdout_has_encoding_attribute(self):
+        c = Capture()
+        c.start()
+        self.assertNotEqual(sys.stdout, sys.__stdout__)
+        self.assertTrue(hasattr(sys.stdout, 'encoding'))
+        c.end()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Some programs expect this attribute, and use it to encode strings before writing to stdout. If it's not there, they fail with an AttributeError.