### PR TITLE
Provide a __main__ entry point

### DIFF
--- a/nose/__main__.py
+++ b/nose/__main__.py
@@ -3,6 +3,6 @@ import sys
 from nose.core import run_exit
 
 if sys.argv[0].endswith('__main__.py'):
-    sys.argv[0] = 'python -m nose'
+    sys.argv[0] = '%s -m nose' % sys.executable
 
 run_exit()


### PR DESCRIPTION
Provide nose.**main**, so nose can be invoked as python -m nose

Closes: #634
