### PR TITLE
Fix #637: nose install fails w/ traceback using python 3.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ try:
         from setuptools.command.easy_install import easy_install
 
         def wrap_write_script(self, script_name, contents, *arg, **kwarg):
+            if script_name.endswith('.exe'):
+                return self._write_script(script_name, contents, *arg, **kwarg)
+
             bad_text = re.compile(
                 "\n"
                 "sys.exit\(\n"


### PR DESCRIPTION
To cope with multiprocessing, nose attempts to rewrite some scripts.  It
turns out that some of the "scripts" are actually executables.  Under
Python 2.x, we'd just perform the substitution on the executable too,
but it never matched anything, and therefore, never replaced any bytes.
Under Python 3, that tactic no longer works because the scripts come as
a string, while the executables come as bytes.  We shouldn't try to
rewrite an executable anyways, so let's just skip them.
