### PR TITLE
Fix a twisted test to work with Twisted 12.3.0 or better.

### DIFF
--- a/functional_tests/test_program.py
+++ b/functional_tests/test_program.py
@@ -110,6 +110,8 @@ class TestTestProgram(unittest.TestCase):
                            exit=False)
         res = runner.result
         print stream.getvalue()
+        print "-----"
+        print repr(res)
 
         # some versions of twisted.trial.unittest.TestCase have
         # runTest in the base class -- this is wrong! But we have
@@ -123,7 +125,15 @@ class TestTestProgram(unittest.TestCase):
                          (expect, res.testsRun))
         assert not res.wasSuccessful()
         assert len(res.errors) == 1
-        assert len(res.failures) == 2
+
+        # In 12.3, Twisted made their skip functionality match unittests, so the
+        # skipped test is no longer reported as a failure.
+        import twisted
+        v = twisted.version
+        if (v.major, v.minor) >= (12, 3):
+            assert len(res.failures) == 1
+        else:
+            assert len(res.failures) == 2
 
     def test_issue_130(self):
         """Collect and run tests in support/issue130 without error.


### PR DESCRIPTION
Twisted has updated trial to work better with unittest's test runner.
As a result, skipped tests are no longer reported as failures.  Since
this is the desired result, fix the test to no longer expect a failure
for the skipped test.  This was tested from Twisted 10.0 to 12.3.
