### PR TITLE
Fix broken duplicate handler detection.

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -367,7 +367,19 @@ class Config(object):
 
         # only add our default handler if there isn't already one there
         # this avoids annoying duplicate log messages.
-        if handler not in logger.handlers:
+        found = False
+        if self.debugLog:
+            debugLogAbsPath = os.path.abspath(self.debugLog)
+            for h in logger.handlers:
+                if type(h) == logging.FileHandler and \
+                        h.baseFilename == debugLogAbsPath:
+                    found = True
+        else:
+            for h in logger.handlers:
+                if type(h) == logging.StreamHandler and \
+                        h.stream == self.logStream:
+                    found = True
+        if not found:
             logger.addHandler(handler)
 
         # default level


### PR DESCRIPTION
The old logic is broken (at least with newer versions of Python).  New
handler objects are created, and there is no mechanism for comparison,
so it resorts to using the object id.  This means that duplicate
handlers are not detected at all.  Let's check the baseFilename of
FileHandlers and the stream attribute of StreamHandlers as a way of
detecting duplicates instead.

With this change, the repeated log messages are greatly reduced.
