### PR TITLE
Remove reference to deleted file from the docs

### DIFF
--- a/doc/further_reading.rst
+++ b/doc/further_reading.rst
@@ -5,7 +5,6 @@ Further reading
    :maxdepth: 2
 
    doc_tests/test_addplugins/test_addplugins.rst
-   doc_tests/test_coverage_html/coverage_html.rst
    doc_tests/test_doctest_fixtures/doctest_fixtures.rst
    doc_tests/test_init_plugin/init_plugin.rst
    doc_tests/test_issue089/unwanted_package.rst


### PR DESCRIPTION
File doc_tests/test_coverage_html/coverage_html.rst was deleted in
commit 6347cd149f5f5f9f06ade7d635dc52245fd50124.
