### PR TITLE
Correctly detect the coverage module under Python 3.3.

### DIFF
--- a/functional_tests/test_coverage_plugin.py
+++ b/functional_tests/test_coverage_plugin.py
@@ -1,5 +1,6 @@
 """Test the coverage plugin."""
 import os
+import sys
 import unittest
 import shutil
 
@@ -10,7 +11,11 @@ support = os.path.join(os.path.dirname(__file__), 'support')
 
 try:
     import coverage
-    hasCoverage = True
+
+    # Python 3.3 may accidentally pick up our support area when running the unit
+    # tests.  Look for the coverage attribute to make sure we've got the right
+    # package.
+    hasCoverage = hasattr(coverage, 'coverage')
 except ImportError:
     hasCoverage = False
 

--- a/nose/plugins/cover.py
+++ b/nose/plugins/cover.py
@@ -104,6 +104,8 @@ class Coverage(Plugin):
         if self.enabled:
             try:
                 import coverage
+                if not hasattr(coverage, 'coverage'):
+                    raise ImportError("Unable to import coverage module")
             except ImportError:
                 log.error("Coverage not available: "
                           "unable to import coverage module")


### PR DESCRIPTION
Python 3.3 has namespace packages (PEP 420) and the coverage support
area is being picked up as one.  As a result, when trying to run tests,
the current infrastructure believes that coverage is installed when it's
not, leading to several test failures.  Let's do an additional check to
make sure we have the real coverage package installed.
