### PR TITLE
Make test_multiprocessing.test_keyboardinterrupt much more reliable.

### DIFF
--- a/functional_tests/test_multiprocessing/support/fake_nosetest.py
+++ b/functional_tests/test_multiprocessing/support/fake_nosetest.py
@@ -8,7 +8,10 @@ from nose.plugins.manager import PluginManager
 
 if __name__ == '__main__':
     if len(sys.argv) < 3:
-        print "USAGE: %s TEST_FILE LOG_FILE" % sys.argv[0]
+        print "USAGE: %s TEST_FILE LOG_FILE KILL_FILE" % sys.argv[0]
         sys.exit(1)
     os.environ['NOSE_MP_LOG']=sys.argv[2]
-    nose.main(defaultTest=sys.argv[1], argv=[sys.argv[0],'--processes=1','-v'], config=Config(plugins=PluginManager(plugins=[MultiProcess()])))
+    os.environ['NOSE_MP_KILL']=sys.argv[3]
+    nose.main(
+            defaultTest=sys.argv[1], argv=[sys.argv[0],'--processes=1','-v'],
+            config=Config(plugins=PluginManager(plugins=[MultiProcess()])))

--- a/functional_tests/test_multiprocessing/support/keyboardinterrupt.py
+++ b/functional_tests/test_multiprocessing/support/keyboardinterrupt.py
@@ -7,17 +7,24 @@ if 'NOSE_MP_LOG' not in os.environ:
     raise Exception('Environment variable NOSE_MP_LOG is not set')
 
 logfile = os.environ['NOSE_MP_LOG']
+killfile = os.environ['NOSE_MP_KILL']
 
 def log(w):
     f = open(logfile, 'a')
     f.write(w+"\n")
     f.close()
+
+def touch_killfile():
+    f = open(killfile,'wb')
+    f.close()
+
 #make sure all tests in this file are dispatched to the same subprocess
 def setup():
     log('setup')
 
 def test_timeout():
     log('test_timeout')
+    touch_killfile()
     sleep(2)
     log('test_timeout_finished')
 

--- a/functional_tests/test_multiprocessing/support/keyboardinterrupt_twice.py
+++ b/functional_tests/test_multiprocessing/support/keyboardinterrupt_twice.py
@@ -7,11 +7,17 @@ if 'NOSE_MP_LOG' not in os.environ:
     raise Exception('Environment variable NOSE_MP_LOG is not set')
 
 logfile = os.environ['NOSE_MP_LOG']
+killfile = os.environ['NOSE_MP_KILL']
 
 def log(w):
     f = open(logfile, 'a')
     f.write(w+"\n")
     f.close()
+
+def touch_killfile():
+    f = open(killfile,'wb')
+    f.close()
+
 #make sure all tests in this file are dispatched to the same subprocess
 def setup():
     '''global logfile
@@ -21,6 +27,7 @@ def setup():
 
 def test_timeout():
     log('test_timeout')
+    touch_killfile()
     sleep(2)
     log('test_timeout_finished')
 
@@ -30,5 +37,6 @@ def test_pass():
 
 def teardown():
     log('teardown')
+    touch_killfile()
     sleep(10)
     log('teardown_finished')

--- a/nose/plugins/multiprocess.py
+++ b/nose/plugins/multiprocess.py
@@ -520,6 +520,7 @@ class MultiProcessTestRunner(TextTestRunner):
             for worker in workers:
                 if worker.is_alive():
                     worker.terminate()
+
             if thrownError: raise thrownError
             else: raise
 


### PR DESCRIPTION
It turns out that even under Linux, start up times for subprocesses can
vary considerably.  As with most threading/multiprocess-based solutions,
sleep() proves to be an inadequate solution to knowing when to send a
signal to interrupt a waiting process.  We may end up sending the kill
signal before the child process is on the right statement, causing some
assertions to fail in our tests.

Instead, let's introduce the concept of a kill file in these tests.  The
kill file will be generated by the unit-under-test, and we'll wait for
them to show up.  This works much better since the kill file is created
just before the sleep() in the unit-under-test.  Once we detect the kill
file, then we can remove it, and fire off the signal.  Where I was
seeing random failures before, I no longer see them now.
