### PR TITLE
Corrected a module path reference

### DIFF
--- a/functional_tests/doc_tests/test_multiprocess/multiprocess.rst
+++ b/functional_tests/doc_tests/test_multiprocess/multiprocess.rst
@@ -9,7 +9,7 @@ Parallel Testing with nose
 
 ..
 
-Using the `nose.plugin.multiprocess` plugin, you can parallelize a
+Using the `nose.plugins.multiprocess` plugin, you can parallelize a
 test run across a configurable number of worker processes. While this can
 speed up CPU-bound test runs, it is mainly useful for IO-bound tests
 that spend most of their time waiting for data to arrive from someplace


### PR DESCRIPTION
A very minor change, but one that got me while using the page: To use MultiProcess you have to import nose.plugins.multiprocess not  **nose.plugin.multiprocess**
