### PR TITLE
Add missing format parameter in error message

### DIFF
--- a/nose/util.py
+++ b/nose/util.py
@@ -364,7 +364,7 @@ def split_test_name(test):
                 # nonsense like foo:bar:baz
                 raise ValueError("Test name '%s' could not be parsed. Please "
                                  "format test names as path:callable or "
-                                 "module:callable.")
+                                 "module:callable." % (test,))
     elif not tail:
         # this is a case like 'foo:bar/'
         # : must be part of the file path, so ignore it


### PR DESCRIPTION
Hello,

When making a mistake on the module:testname syntax, I encountered a stray `'%s'` in an error message:

```
$ ./bin/nosetests nose.a:b:c
[...]
ValueError: Test name '%s' could not be parsed. Please format test names as path:callable or module:callable.
```

This turns it into:

```
$ ./bin/nosetests nose.a:b:c
[...]
ValueError: Test name 'nose.a:b:c' could not be parsed. Please format test names as path:callable or module:callable.
```

Thanks for your work.
