### PR TITLE
Switch docs sidebar tracker link to current GitHub instead of old Google code site

### DIFF
--- a/doc/.templates/indexsidebar.html
+++ b/doc/.templates/indexsidebar.html
@@ -33,7 +33,7 @@
   </li>
 </ul>
 
-<h3><a href="http://code.google.com/p/python-nose/">Tracker</a></h3>
+<h3><a href="https://github.com/nose-devs/nose/">Tracker</a></h3>
 <ul><li>Report bugs, request features, wik the wiki, browse source.</li></ul>
 
 <h3>Other links</h3>


### PR DESCRIPTION
Currently, the docs index page's sidebar link "Tracker" points to the old code.google.com site. The code.google.com site just advises the reader to go to GitHub. This pull request cuts out the extra step.
