### PR TITLE
Making some pep8 fixes to nose.config. Changed the type-casting for the ...

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -19,7 +19,7 @@ config_files = [
     "~/.noserc",
     # Windows users will prefer this
     "~/nose.cfg"
-    ]
+]
 
 # plaforms on which the exe check defaults to off
 # Windows and IronPython
@@ -255,7 +255,7 @@ class Config(object):
     def _parseArgs(self, argv, cfg_files):
         def warn_sometimes(msg, name=None, filename=None):
             if (hasattr(self.plugins, 'excludedOption') and
-                self.plugins.excludedOption(name)):
+                    self.plugins.excludedOption(name)):
                 msg = ("Option %r in config file %r ignored: "
                        "excluded by runtime environment" %
                        (name, filename))
@@ -347,8 +347,8 @@ class Config(object):
     def configureLogging(self):
         """Configure logging for nose, or optionally other packages. Any logger
         name may be set with the debug option, and that logger will be set to
-        debug level and be assigned the same handler as the nose loggers, unless
-        it already has a handler.
+        debug level and be assigned the same handler as the nose loggers, 
+        unless it already has a handler.
         """
         if self.loggingConfig:
             from logging.config import fileConfig
@@ -419,7 +419,7 @@ class Config(object):
                 log.info("Set working dir to %s", abs_path)
                 self.workingDir = abs_path
                 if self.addPaths and \
-                       os.path.exists(os.path.join(abs_path, '__init__.py')):
+                        os.path.exists(os.path.join(abs_path, '__init__.py')):
                     log.info("Working directory %s is a package; "
                              "adding to sys.path" % abs_path)
                     add_path(abs_path)
@@ -443,10 +443,9 @@ class Config(object):
         """
         if self.parser:
             return self.parser
-        env = self.env
         parser = self.parserClass(doc)
         parser.add_option(
-            "-V","--version", action="store_true",
+            "-V", "--version", action="store_true",
             dest="version", default=False,
             help="Output nose version and exit")
         parser.add_option(
@@ -462,7 +461,7 @@ class Config(object):
         parser.add_option(
             "--verbosity", action="store", dest="verbosity",
             metavar='VERBOSITY',
-            type="int", help="Set verbosity; --verbosity=2 is "
+            type=int, help="Set verbosity; --verbosity=2 is "
             "the same as -v")
         parser.add_option(
             "-q", "--quiet", action="store_const", const=0, dest="verbosity",
@@ -480,8 +479,7 @@ class Config(object):
             "May be specified multiple times. The first directory passed "
             "will be used as the working directory, in place of the current "
             "working directory, which is the default. Others will be added "
-            "to the list of tests to execute. [NOSE_WHERE]"
-            )
+            "to the list of tests to execute. [NOSE_WHERE]")
         parser.add_option(
             "--py3where", action="append", dest="py3where",
             metavar="PY3WHERE",
@@ -490,8 +488,7 @@ class Config(object):
             "Python 3.x or above.  Note that, if present under 3.x, this "
             "option completely replaces any directories specified with "
             "'where', so the 'where' option becomes ineffective. "
-            "[NOSE_PY3WHERE]"
-            )
+            "[NOSE_PY3WHERE]")
         parser.add_option(
             "-m", "--match", "--testmatch", action="store",
             dest="testMatch", metavar="REGEX",


### PR DESCRIPTION
Made pep8 fixes to config.py and test_config.py. Most importantly changed the type casting of the --verbosity option from "int" to int. I tested it on python 2.4, 2.5, 2.6 and 2.7 and it seems to work although the usage is not proper according to documentation. The change was made in order to utilize argparse with nose arguments. Coding would go something like this:

from argparse import ArgumentParser

from nose.config import Config

config = Config()
config.parserClass = ArgumentParser
config.parserClass.add_option = ArgumentParser.add_argument
parser = config.getParser()

This way we can extend nose onto newer platforms utilizing argparse

I also fixed up an existing unit test in test_config, and wrote a new one to verify that the --verbosity type works
