### PR TITLE
Fix issue #374

### DIFF
--- a/doc/.templates/indexsidebar.html
+++ b/doc/.templates/indexsidebar.html
@@ -1,6 +1,6 @@
 <h3><a href="http://pypi.python.org/pypi/nose/">Download</a></h3>
 <ul>
-  <li><a href="http://pypi.python.org/pypi/nose/">
+  <li><a href="http://pypi.python.org/pypi/nose/{{ release }}">
       Current version: {{ release }}</a>
   </li>
 </ul>
@@ -16,11 +16,6 @@
 
 <h3>Community</h3>
 <ul>
-  <li><a href="http://groups.google.com/group/nose-announce">
-    Announcement list</a>
-    <ul><li>Sign up to receive email announcements
-        of new releases</li></ul>
-  </li>
   <li><a href="http://groups.google.com/group/nose-users">
     Users' discussion list</a>
     <ul><li>Talk about using nose. Get help. Give help!</li></ul>
@@ -39,7 +34,7 @@
 <h3>Other links</h3>
 <ul>
   <li>
-    <a href="http://codespeak.net/py/current/doc/test.html">py.test</a>
+    <a href="http://pytest.org">pytest</a>
   </li>
   <li>
     <a href="http://peak.telecommunity.com/DevCenter/setuptools">
@@ -47,10 +42,3 @@
   </li>
 </ul>
 
-<h3>Older versions</h3>
-<ul>
-  <li><a href="../0.10.4/">nose 0.10, the previous major
-      release.</a></li>
-  <li><a href="../0.9.3/">nose 0.9.3, a very old version that you
-      shouldn't use.</a></li>
-</ul>


### PR DESCRIPTION
Update some of the links in the sidebar of the docs:
- Remved "Older Versions" section that contained broken links
- Fixed link to pytest
- Fixed "Current Version" link to pypi to link to current version
- Removed link to old and unused announcement mailing list
