### PR TITLE
Catch KeyboardInterrupt during test run

### DIFF
--- a/nose/core.py
+++ b/nose/core.py
@@ -58,7 +58,10 @@ class TextTestRunner(unittest.TextTestRunner):
 
         result = self._makeResult()
         start = time.time()
-        test(result)
+        try:
+            test(result)
+        except KeyboardInterrupt:
+            pass
         stop = time.time()
         result.printErrors()
         result.printSummary(start, stop)


### PR DESCRIPTION
On large projects where there are thousands of tests, one may want to cancel the current test run when some tests fail but would still like to see the error summary and stack traces. I know there's `--pdb` and `--pdf-failures` options but pressing ^C is a lot more flexible and convenient.
