### PR TITLE
Small fix for a problem combining clint and nosetests.

### DIFF
--- a/nose/plugins/xunit.py
+++ b/nose/plugins/xunit.py
@@ -139,6 +139,10 @@ class Tee(object):
         for s in self._streams:
             s.flush()
 
+    def isatty(self):
+        return False
+
+
 class Xunit(Plugin):
     """This plugin provides test results in the standard XUnit XML format."""
     name = 'xunit'


### PR DESCRIPTION
Clint uses isatty() to determine if to print a color, but the Tee object emulating a stdout socket do miss this method.
