### PR TITLE
Fix #649: UnicodeDecodeError when an exception contains encoded strings

### DIFF
--- a/functional_tests/support/issue649/test.py
+++ b/functional_tests/support/issue649/test.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+class TestUnicodeInAssertion(unittest.TestCase):
+
+    def test_unicodeInAssertion(self):
+        print "Wurst!"
+        raise ValueError("Käse!")

--- a/functional_tests/test_issue_649.py
+++ b/functional_tests/test_issue_649.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+import unittest
+from nose.plugins.capture import Capture
+from nose.plugins import PluginTester
+
+support = os.path.join(os.path.dirname(__file__), 'support')
+
+class TestIssue649(PluginTester, unittest.TestCase):
+    activate = ''
+    args = ['-v']
+    plugins = [Capture()]
+    suitepath = os.path.join(support, 'issue649')
+
+    def runTest(self):
+        print str(self.output)
+        assert 'UnicodeDecodeError' not in self.output

--- a/nose/plugins/capture.py
+++ b/nose/plugins/capture.py
@@ -89,7 +89,12 @@ class Capture(Plugin):
         if isinstance(ev, BaseException):
             if hasattr(ev, '__unicode__'):
                 # 2.6+
-                ev = unicode(ev)
+                try:
+                    ev = unicode(ev)
+                except UnicodeDecodeError:
+                    # We need a unicode string... take our best shot at getting,
+                    # since we don't know what the original encoding is in.
+                    ev = str(ev).decode('utf8', 'replace')
             else:
                 # 2.5-
                 if not hasattr(ev, 'message'):


### PR DESCRIPTION
The issue stems from the fact that when you use a coding line in the
Python file, and raise an exception that contains unicode characters,
the message in the exception is an encoded string.  We need to get it
converted into unicode, but simply calling `unicode(ev)` doesn't work,
as that often fails with a `UnicodeDecodeError` because it assumes
`ascii` encoding by default.

This fixes the issue by trying to decode the stream as UTF-8, and uses
replacement on errors.  It's not ideal, but the best we can do since
we don't know the encoding of the message string.

Thanks to Christoph Zwerschke for the test case.
