### PR TITLE
Fix #687: verbosity is not a flag

### DIFF
--- a/nose/commands.py
+++ b/nose/commands.py
@@ -155,9 +155,14 @@ else:
 
         def cfgToArg(self, optname, value):
             argv = []
-            if flag(value):
+            long_optname = '--' + optname
+            opt = self.__parser.get_option(long_optname)
+            if opt.action in ('store_true', 'store_false'):
+                if not flag(value):
+                    raise ValueError("Invalid value '%s' for '%s'" % (
+                        value, optname))
                 if _bool(value):
-                    argv.append('--' + optname)
+                    argv.append(long_optname)
             else:
-                argv.extend(['--' + optname, value])
+                argv.extend([long_optname, value])
             return argv


### PR DESCRIPTION
The issue is that `nosetests.cfgToArg()` was treating the verbosity flag
as a boolean when you set the value to `1` in `setup.cfg`.  Instead of
using the `flag()` helper, let's consult the option object and see if
the action is `store_true` or `store_false`.
