### PR TITLE
Making setOutputStream() chainable so that multiple stream modifying plugins can coexist

### DIFF
--- a/nose/plugins/base.py
+++ b/nose/plugins/base.py
@@ -612,6 +612,8 @@ class IPluginInterface(object):
         :param stream: stream object; send your output here
         :type stream: file-like object
         """
+        pass
+    setOutputStream.chainable = True
 
     def startContext(self, context):
         """Called before context setup and the running of tests in the


### PR DESCRIPTION
This will allow for peaceful coexistence of multiple stream modifying plugins. With this change you can run testid and htmloutput simultaneously, without one plugin monopolizing stream handle. 
