### PR TITLE
Look for unittest2 in skip plugin

### DIFF
--- a/nose/plugins/skip.py
+++ b/nose/plugins/skip.py
@@ -9,15 +9,22 @@ is enabled by default but may be disabled with the ``--no-skip`` option.
 from nose.plugins.errorclass import ErrorClass, ErrorClassPlugin
 
 
+# on SkipTest:
+#  - unittest SkipTest is first preference, but it's only available
+#    for >= 2.7
+#  - unittest2 SkipTest is second preference for older pythons.  This
+#    mirrors logic for choosing SkipTest exception in testtools
+#  - if none of the above, provide custom class
 try:
-    # 2.7
     from unittest.case import SkipTest
 except ImportError:
-    # 2.6 and below
-    class SkipTest(Exception):
-        """Raise this exception to mark a test as skipped.
-        """
-    pass
+    try:
+        from unittest2.case import SkipTest
+    except ImportError:
+        class SkipTest(Exception):
+            """Raise this exception to mark a test as skipped.
+            """
+            pass
 
 
 class Skip(ErrorClassPlugin):


### PR DESCRIPTION
If unittest2 is available, try to use its SkipTest class rather than a
nose internal version.  Inspired by better integration with testtools
for older python releases (see [1]).

[1] https://review.openstack.org/#/c/33056/
