### PR TITLE
Fix #692: UnicodeDecodeError in xunit when capturing stdout, stderr

### DIFF
--- a/functional_tests/support/issue692/test.py
+++ b/functional_tests/support/issue692/test.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+class TestUnicodeInAssertion(unittest.TestCase):
+
+    def test_unicodeInAssertion(self):
+        print("テスト!")
+        assert False

--- a/functional_tests/test_xunit.py
+++ b/functional_tests/test_xunit.py
@@ -91,3 +91,19 @@ class TestIssue680(PluginTester, unittest.TestCase):
         f.close()
         print result
         assert 'tests="1" errors="0" failures="0" skip="0"' in result
+
+
+class TestIssue692(PluginTester, unittest.TestCase):
+    activate = '--with-xunit'
+    args = ['-v','--xunit-file=%s' % xml_results_filename]
+    plugins = [Capture(), Xunit()]
+    suitepath = os.path.join(support, 'issue692')
+
+    def runTest(self):
+        print str(self.output)
+        f = open(xml_results_filename,'r')
+        result = f.read()
+        f.close()
+        print result
+        assert 'tests="1" errors="0" failures="1" skip="0"' in result
+        assert 'exceptions.AssertionError' in result

--- a/nose/plugins/xunit.py
+++ b/nose/plugins/xunit.py
@@ -123,6 +123,8 @@ def format_exception(exc_info):
     # work ourselves if ev is a string.
     if isinstance(ev, basestring):
         tb_data = ''.join(traceback.format_tb(tb))
+        if isinstance(ev, unicode):
+            ev = ev.encode('UTF-8')
         return tb_data + ev
     else:
         return ''.join(traceback.format_exception(*exc_info))


### PR DESCRIPTION
Enable xunit to output Unicode characters to an XML report
when catured stdout and/or stderr contain Unicode characters.
