### PR TITLE
Nosetests fail when run with processes

### DIFF
--- a/nose/plugins/cover.py
+++ b/nose/plugins/cover.py
@@ -148,13 +148,14 @@ class Coverage(Plugin):
         """
         log.debug("Coverage begin")
         self.skipModules = sys.modules.keys()[:]
-        if self.coverErase:
-            log.debug("Clearing previously collected coverage statistics")
-            self.coverInstance.combine()
-            self.coverInstance.erase()
-        self.coverInstance.exclude('#pragma[: ]+[nN][oO] [cC][oO][vV][eE][rR]')
-        self.coverInstance.load()
-        self.coverInstance.start()
+        if self.coverInstance:
+            if self.coverErase:
+                log.debug("Clearing previously collected coverage statistics")
+                self.coverInstance.combine()
+                self.coverInstance.erase()
+            self.coverInstance.exclude('#pragma[: ]+[nN][oO] [cC][oO][vV][eE][rR]')
+            self.coverInstance.load()
+            self.coverInstance.start()
 
     def report(self, stream):
         """


### PR DESCRIPTION
When run with the version on master and a setup.cfg with

    processes=8
    process-timeout=120

I get one of these messages for each of my processes:

    	AttributeError: 'NoneType' object has no attribute 'exclude'

from this call stack:

    Traceback (most recent call last):
      File "/usr/local/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
        self.run()
      File "/usr/local/lib/python2.7/multiprocessing/process.py", line 114, in run
        self._target(*self._args, **self._kwargs)
      File "/home/hbrown/.virtualenvs/access_manager/lib/python2.7/site-packages/nose/plugins/multiprocess.py", line 652, in runner
        keyboardCaught, shouldStop, loaderClass, resultClass, config)
      File "/home/hbrown/.virtualenvs/access_manager/lib/python2.7/site-packages/nose/plugins/multiprocess.py", line 669, in __runner
        config.plugins.begin()
      File "/home/hbrown/.virtualenvs/access_manager/lib/python2.7/site-packages/nose/plugins/manager.py", line 99, in __call__
        return self.call(*arg, **kw)
      File "/home/hbrown/.virtualenvs/access_manager/lib/python2.7/site-packages/nose/plugins/manager.py", line 167, in simple
        result = meth(*arg, **kw)
      File "/home/hbrown/.virtualenvs/access_manager/lib/python2.7/site-packages/nose/plugins/cover.py", line 155, in begin
        self.coverInstance.exclude('#pragma[: ]+[nN][oO] [cC][oO][vV][eE][rR]')
    AttributeError: 'NoneType' object has no attribute 'exclude'

The line in question is:

    self.coverInstance.exclude('#pragma[: ]+[nN][oO] [cC][oO][vV][eE][rR]')

So `self.coverInstance` is `None`. Making this check for `self.coverInstance` allows the tests to run.

This is a temporary fix, I imagine, It looks like there are several bugs already posted against multiprocessing.