### PR TITLE
Added --cover-nostream flag for coverage plugin to skip stderr stream report

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ In Development
   Patch by Nick Loadholtes.
 - Fixed #447: doctests fail when getpackage() returns None
   Patch by Matthew Brett.
+- Added --cover-nostream flag for coverage plugin to skip stderr stream report.
+  Patch by Sebastian Hanula and Glen Oakley
 
 1.3.0
 

--- a/README.txt
+++ b/README.txt
@@ -105,8 +105,8 @@ Configuration
 
 In addition to passing command-line options, you may also put
 configuration options in your project's *setup.cfg* file, or a .noserc
-or nose.cfg file in your home directory. In any of these standard
-.ini-style config files, you put your nosetests configuration in a
+or nose.cfg file in your home directory. In any of these standard ini-
+style config files, you put your nosetests configuration in a
 "[nosetests]" section. Options are the same as on the command line,
 with the -- prefix removed. For options that are simple switches, you
 must supply a value:
@@ -278,6 +278,11 @@ Options
    it sees a package with the same name in a different location. Set
    this option to disable that behavior.
 
+--no-byte-compile
+
+   Prevent nose from byte-compiling the source into .pyc files while
+   nose is scanning for and running tests.
+
 -a=ATTR, --attr=ATTR
 
    Run only tests that have attributes specified by ATTR [NOSE_ATTR]
@@ -322,6 +327,10 @@ Options
 
    Clear all other logging handlers
 
+--logging-level=DEFAULT
+
+   Set the log level to capture
+
 --with-coverage
 
    Enable plugin Coverage:  Activate a coverage report using Ned
@@ -338,6 +347,11 @@ Options
 --cover-tests
 
    Include test modules in coverage report [NOSE_COVER_TESTS]
+
+--cover-min-percentage=DEFAULT
+
+   Minimum percentage of coverage for teststo pass
+   [NOSE_COVER_MIN_PERCENTAGE]
 
 --cover-inclusive
 
@@ -365,13 +379,21 @@ Options
 
    Produce XML coverage information in file
 
+--cover-nostream
+
+   Disable coverage output to stdout/stderr
+
 --pdb
 
-   Drop into debugger on errors
+   Drop into debugger on failures or errors
 
 --pdb-failures
 
    Drop into debugger on failures
+
+--pdb-errors
+
+   Drop into debugger on errors
 
 --no-deprecated
 
@@ -404,6 +426,11 @@ Options
 
    Find fixtures for a doctest file in module with this name appended
    to the base name of the doctest file
+
+--doctest-options=OPTIONS
+
+   Specify options to pass to doctest. Eg.
+   '+ELLIPSIS,+NORMALIZE_WHITESPACE'
 
 --with-isolation
 
@@ -460,12 +487,15 @@ Options
 
    Spread test run among this many processes. Set a number equal to
    the number of processors or cores in your machine for best results.
-   [NOSE_PROCESSES]
+   Pass a negative number to have the number of processes
+   automatically set to the number of cores. Passing 0 means to
+   disable parallel testing. Default is 0 unless NOSE_PROCESSES is
+   set. [NOSE_PROCESSES]
 
 --process-timeout=SECONDS
 
    Set timeout for return of results from each test runner process.
-   [NOSE_PROCESS_TIMEOUT]
+   Default is 10. [NOSE_PROCESS_TIMEOUT]
 
 --process-restartworker
 

--- a/functional_tests/test_coverage_plugin.py
+++ b/functional_tests/test_coverage_plugin.py
@@ -173,5 +173,35 @@ class TestCoverageMinPercentageWithBranchesTOTALPlugin(
     def runTest(self):
         pass
 
+
+class TestCoverageNoStreamPlugin(PluginTester, unittest.TestCase):
+    activate = "--with-coverage"
+    args = ['-v', '--cover-package=blah', '--cover-nostream', '--cover-html',
+            '--cover-min-percentage', '25']
+    plugins = [Coverage()]
+    suitepath = os.path.join(support, 'coverage')
+
+    def setUp(self):
+        if not hasCoverage:
+            raise unittest.SkipTest('coverage not available; skipping')
+
+        self.cover_file = os.path.join(os.getcwd(), '.coverage')
+        self.cover_html_dir = os.path.join(os.getcwd(), 'cover')
+        if os.path.exists(self.cover_file):
+            os.unlink(self.cover_file)
+        if os.path.exists(self.cover_html_dir):
+            shutil.rmtree(self.cover_html_dir)
+        super(TestCoverageNoStreamPlugin, self).setUp()
+
+    def runTest(self):
+        # Assert no coverage report in output
+        self.assertFalse("blah        4      3    25%   1" in self.output)
+        self.assertTrue("Ran 1 test in" in self.output)
+        # Assert coverage html report is still generated
+        self.assertTrue(os.path.exists(os.path.join(self.cover_html_dir,
+                        'index.html')))
+        # Assert coverage data is still saved
+        self.assertTrue(os.path.exists(self.cover_file))
+
 if __name__ == '__main__':
     unittest.main()

--- a/nose/plugins/cover.py
+++ b/nose/plugins/cover.py
@@ -89,6 +89,11 @@ class Coverage(Plugin):
                           dest="cover_xml_file",
                           metavar="FILE",
                           help="Produce XML coverage information in file")
+        parser.add_option("--cover-nostream", action="store_true",
+                          default=env.get('NOSE_COVER_NOSTREAM'),
+                          dest='cover_nostream',
+                          help="Disable coverage output to stdout/stderr")
+
 
     def configure(self, options, conf):
         """
@@ -115,6 +120,7 @@ class Coverage(Plugin):
         self.coverErase = options.cover_erase
         self.coverTests = options.cover_tests
         self.coverPackages = []
+        self.coverStream = not options.cover_nostream
         if options.cover_packages:
             if isinstance(options.cover_packages, (list, tuple)):
                 cover_packages = options.cover_packages
@@ -168,7 +174,8 @@ class Coverage(Plugin):
                     for name, module in sys.modules.items()
                     if self.wantModuleCoverage(name, module)]
         log.debug("Coverage report will cover modules: %s", modules)
-        self.coverInstance.report(modules, file=stream)
+        if self.coverStream:
+            self.coverInstance.report(modules, file=stream)
         if self.coverHtmlDir:
             log.debug("Generating HTML coverage report")
             self.coverInstance.html_report(modules, self.coverHtmlDir)

--- a/nosetests.1
+++ b/nosetests.1
@@ -1,4 +1,4 @@
-.TH "NOSETESTS" "1" "April 06, 2013" "1.3" "nose"
+.TH "NOSETESTS" "1" "July 19, 2013" "1.3" "nose"
 .SH NAME
 nosetests \- Nicer testing for Python
 .
@@ -413,13 +413,23 @@ Produce XML coverage information in file
 .UNINDENT
 .INDENT 0.0
 .TP
+.B \-\-cover\-nostream
+Disable coverage output to stdout/stderr
+.UNINDENT
+.INDENT 0.0
+.TP
 .B \-\-pdb
-Drop into debugger on errors
+Drop into debugger on failures or errors
 .UNINDENT
 .INDENT 0.0
 .TP
 .B \-\-pdb\-failures
 Drop into debugger on failures
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-pdb\-errors
+Drop into debugger on errors
 .UNINDENT
 .INDENT 0.0
 .TP


### PR DESCRIPTION
Original --cover-nostream option started by Glen Oakley #697 but with fixes and functional test.
