### PR TITLE
Fixed issue with builtin filtering.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 In Development
 
+- The log capture plugin now correctly applies filters that were added
+  using `addFilter`.
 - Corrected a reference to the multiprocessing plugin in the documentation.
   Patch by Nick Loadholtes.
 - Fixed #447: doctests fail when getpackage() returns None

--- a/nose/plugins/logcapture.py
+++ b/nose/plugins/logcapture.py
@@ -85,7 +85,8 @@ class MyMemoryHandler(Handler):
     def truncate(self):
         self.buffer = []
     def filter(self, record):
-        return self.filterset.allow(record.name)
+        if self.filterset.allow(record.name):
+            return Handler.filter(self, record)
     def __getstate__(self):
         state = self.__dict__.copy()
         del state['lock']

--- a/unit_tests/test_logcapture_plugin.py
+++ b/unit_tests/test_logcapture_plugin.py
@@ -155,6 +155,26 @@ class TestLogCapturePlugin(object):
         eq_(1, len(records))
         eq_("++Hello++", records[0])
 
+    def test_builtin_logging_filtering(self):
+        c = LogCapture()
+        c.logformat = '++%(message)s++'
+        c.start()
+        log = logging.getLogger("foobar.something")
+        filtered = []
+        class filter(object):
+            def filter(record):
+                filtered.append(record)
+                return len(filtered) == 1
+            filter = staticmethod(filter)
+        c.handler.addFilter(filter)
+        log.debug("Hello")
+        log.debug("World")
+        c.end()
+        eq_(2, len(filtered))
+        records = c.formatLogRecords()
+        eq_(1, len(records))
+        eq_("++Hello++", records[0])
+
     def test_logging_filter(self):
         env = {'NOSE_LOGFILTER': 'foo,bar'}
         c = LogCapture()


### PR DESCRIPTION
The superclass (which ultimately inherits from 'Handler')
checks against any registered filters, before allowing a
logging record. Nose's logging capture plugin should do the
same, because these filters are allowed to modify the record.

And it can easily happen that the logging format requires
this modification (e.g. add an attribute).
