### PR TITLE
find configuration files in current directory and its parents

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -644,7 +644,19 @@ def all_config_files():
     user = user_config_files()
     if os.path.exists('setup.cfg'):
         return user + ['setup.cfg']
-    return user
+    else:
+        def _parents(d):
+            current_set = d.split(os.path.sep)
+            while current_set:
+                yield(os.path.sep.join(current_set))
+                current_set.pop()
+        parents = _parents(os.getcwd())
+        possible_config_files = [
+            os.path.sep.join((pdir, os.path.basename(config_file)))
+            for config_file in config_files
+            for pdir in parents]
+
+        return user + filter(os.path.exists, possible_config_files)
 
 
 # used when parsing config files


### PR DESCRIPTION
In case you would consider this type of change, here is a patch to read the config files from the current working directory and any of its parents, a la setup.cfg.

The motivating use case is I would like to store configuration options like "attr=!ignore" in a non-user-specific configuration file and have those options apply to whole subdirectories of tests/testable code.

If you would consider a pull request of this sort, let me know, and I will create a larger pull request with proposed documentation changes to reflect this.

There is at least one alternative approach that you may consider: read configuration files from the directories containing the tests, and their parents.

Storing config files near the tests is my preferred approach, but the code would be more complicated and we would change the configuration based on the configuration (since we use the configuration to determine where the test directories are).  I felt this would be too large a pull request unless you were open to that.  Please let me know if you would accept a pull request for this, and I will come up with one.

I can see some objections to this, namely that the test behaviour would change based on the current working directory of the nosetest command, but given all_config_files already allows this, I thought I would propose this new feature anyway.
