### PR TITLE
Xunit output capture fix for logging

### DIFF
--- a/functional_tests/support/issue_out_capture/test.py
+++ b/functional_tests/support/issue_out_capture/test.py
@@ -2,12 +2,15 @@
 
 import unittest
 import logging
-logging.basicConfig()
+import sys
 
-class TestUnicodeInAssertion(unittest.TestCase):
+LOG = logging.getLogger('test_capture_logging')
+LOG.addHandler(logging.StreamHandler())
+
+class TestLoggingWithXunit(unittest.TestCase):
 
     def test_a(self):
-        logging.error('log_1')
+        LOG.error('log_1')
 
     def test_b(self):
-        logging.error('log_2')
+        LOG.error('log_2')

--- a/functional_tests/support/issue_out_capture/test.py
+++ b/functional_tests/support/issue_out_capture/test.py
@@ -2,7 +2,7 @@
 
 import unittest
 import logging
-
+logging.basicConfig()
 
 class TestUnicodeInAssertion(unittest.TestCase):
 

--- a/functional_tests/support/issue_out_capture/test.py
+++ b/functional_tests/support/issue_out_capture/test.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import logging
+
+
+class TestUnicodeInAssertion(unittest.TestCase):
+
+    def test_a(self):
+        logging.error('log_1')
+
+    def test_b(self):
+        logging.error('log_2')

--- a/functional_tests/test_xunit.py
+++ b/functional_tests/test_xunit.py
@@ -6,6 +6,7 @@ import unittest
 from nose.plugins.capture import Capture
 from nose.plugins.xunit import Xunit
 from nose.plugins.skip import Skip
+from nose.plugins.logcapture import LogCapture
 from nose.plugins import PluginTester
 
 support = os.path.join(os.path.dirname(__file__), 'support')
@@ -108,3 +109,20 @@ class TestIssue700(PluginTester, unittest.TestCase):
         assert 'tests="1" errors="0" failures="0" skip="0"' in result
         assert 'line1\n' in result
         assert 'line2\n' in result
+
+
+class TestOutCaptureIssue(PluginTester, unittest.TestCase):
+    activate = '--with-xunit'
+    args = ['-v', '--xunit-file=%s' % xml_results_filename]
+    plugins = [Xunit(), Skip()]
+    suitepath = os.path.join(support, 'issue_out_capture')
+
+    def runTest(self):
+        print str(self.output)
+        f = open(xml_results_filename,'r')
+        result = f.read()
+        f.close()
+        print result
+        assert 'tests="2" errors="0" failures="0" skip="0"' in result
+        assert 'log_1\n' in result
+        assert 'log_2\n' in result

--- a/functional_tests/test_xunit.py
+++ b/functional_tests/test_xunit.py
@@ -124,5 +124,5 @@ class TestOutCaptureIssue(PluginTester, unittest.TestCase):
         f.close()
         print result
         assert 'tests="2" errors="0" failures="0" skip="0"' in result
-        assert 'log_1\n' in result
-        assert 'log_2\n' in result
+        assert 'log_1' in result
+        assert 'log_2' in result

--- a/unit_tests/test_xunit.py
+++ b/unit_tests/test_xunit.py
@@ -276,7 +276,7 @@ class TestXMLOutputWithXML(unittest.TestCase):
         except RuntimeError:
             some_err = sys.exc_info()
 
-        self.x.startContext(None)
+        self.x._startCapture()
 
         # call addError without startTest
         # which can happen if setup() raises an error


### PR DESCRIPTION
Xunit plugin captures `stdout` and `stderr` and attaches it to generated xml file. To manage it it monkey-patches `sys.stdout` and `sys.stderr`. This monkey patching is done after module was loaded and replayed before every test. This approach makes it incompatible with python `logging` library. 

When we use logging library either in test itself or in tested part of code typical approach would be to create `StreamHandler` only once and then to use this handler. It means that `StreamHandler` is carrying it's own reference to stderr and is not using `sys.stderr` before every write to stderr.

Please consider this example:

```
import unittest
import logging
logging.basicConfig()

class T(unittest.TestCase):
    def test_a(self):
        logging.error('ERROR')
```

This 'ERROR' string won't be captured by Xunit plugin because `logging` was initialized on module import and `sys.stderr` was monkey-patched after it.