### PR TITLE
Fix 8-bit string dependencies in xunit plugin

### DIFF
--- a/nose/plugins/xunit.py
+++ b/nose/plugins/xunit.py
@@ -52,7 +52,7 @@ from nose.exc import SkipTest
 from nose.pyversion import UNICODE_STRINGS
 
 # Invalid XML characters, control characters 0-31 sans \t, \n and \r
-CONTROL_CHARACTERS = re.compile(r"[\000-\010\013\014\016-\037]")
+CONTROL_CHARACTERS = re.compile(r"[\000-\010\013\014\016-\037\0200-\0377]")
 
 TEST_ID = re.compile(r'^(.*?)(\(.*\))$')
 


### PR DESCRIPTION
Python strings are 8-bit and allow characters from 128-255 range.
Most other languages support 0-127 only (ascii).

This is specifically visible in jenkins reporting tool for xunit reports.
