### PR TITLE
Continous run tests.

### DIFF
--- a/nose/core.py
+++ b/nose/core.py
@@ -23,6 +23,12 @@ compat_24 = sys.version_info >= (2, 4)
 __all__ = ['TestProgram', 'main', 'run', 'run_exit', 'runmodule', 'collector',
            'TextTestRunner']
 
+# State of runner:
+# * normal - regular business
+# * looping - running tests in main loop
+# * exiting - running final teardown
+NOSE = {'state': 'normal'}
+
 
 class TextTestRunner(unittest.TextTestRunner):
     """Test runner that uses nose's TextTestResult to enable errorClasses,
@@ -201,11 +207,117 @@ class TestProgram(unittest.TestProgram):
         plug_runner = self.config.plugins.prepareTestRunner(self.testRunner)
         if plug_runner is not None:
             self.testRunner = plug_runner
-        result = self.testRunner.run(self.test)
-        self.success = result.wasSuccessful()
+
+        self._selectRunMode()
+
         if self.exit:
             sys.exit(not self.success)
         return self.success
+
+    def _runTestSuite(self):
+        """Run the test suite.
+        """
+        result = self.testRunner.run(self.test)
+        self.success = result.wasSuccessful()
+
+    def _selectRunMode(self):
+        """Select running mode for tests.
+        """
+        try:
+            if not self.config.options.enable_plugin_loop:
+                raise AttributeError('Loop plugin not enabled')
+        except AttributeError:
+            # Run in normal mode.
+            self._runTestSuite()
+        else:
+            # Run in loop mode.
+            try:
+                NOSE['state'] = 'looping'
+                self._loopTests()
+            except KeyboardInterrupt:
+                pass
+            finally:
+                print "Leaving loop..."
+                # Fake that teardown was run, so we do a final teardown
+                # with special attributes.
+                NOSE['state'] = 'exiting'
+                self.test.was_torndown = False
+                self.test.factory.was_torndown = {}
+                self.test.tearDown()
+                self.success = 0
+
+    def _loopTests(self):
+        """Loop tests waiting for changes.
+        """
+        have_changes = False
+        before_state = []
+        run_tests = True
+        exit = False
+        while run_tests and not exit:
+            after_state = self.getTestModules(self.test)
+            if not after_state:
+                have_changes = True
+                run_tests = False
+            elif self.wereTestsChanged(before_state, after_state):
+                for test in before_state:
+                    reload(test[0].context)
+
+                # Create a new suite so that we will reload setup
+                # and teardown.
+                from nose.suite import ContextSuiteFactory
+                self.testLoader.suiteClass = ContextSuiteFactory(
+                    config=self.testLoader.config)
+                self.createTests()
+                before_state = after_state
+                have_changes = True
+            else:
+                have_changes = False
+
+            if not have_changes:
+                print "Waiting for changes... (Ctr+C to quit)"
+                time.sleep(1)
+                continue
+
+            print "Starting new tests..."
+            self._runTestSuite()
+
+    def getTestModules(self, test):
+        """Return a list of all test modules and their source paths.
+        """
+        import inspect
+        from types import ModuleType
+        from nose.suite import ContextSuite
+        result = []
+        for candidate in test._get_tests():
+            context = candidate.context
+            if not context:
+                continue
+
+            if not isinstance(context, ModuleType):
+                continue
+
+            if isinstance(candidate, ContextSuite):
+                result.extend(self.getTestModules(candidate))
+            try:
+                path = inspect.getsourcefile(context)
+            except TypeError:
+                # No source for this module.
+                continue
+            modified_time = os.stat(path).st_mtime
+            result.append((candidate, modified_time))
+
+        return result
+
+    def wereTestsChanged(self, before_state, after_state):
+        """Return True if tests were changed.
+        """
+        if len(before_state) != len(after_state):
+            return True
+
+        for before_test, after_test in zip(before_state, after_state):
+            if before_test[1] != after_test[1]:
+                return True
+        return False
 
     def showPlugins(self):
         """Print list of available plugins.

--- a/nose/plugins/loop.py
+++ b/nose/plugins/loop.py
@@ -1,0 +1,55 @@
+"""Loop mode plugin.
+
+Simple plugging to signal that we want to run tests in a loop.
+
+    $ nosetets --with-loop
+    # TEST LOOP HERE... press Ctrl+C to exit.
+
+The ``NOSE['status']`` shared variable is used to signal the state/mode in
+which nose is running. It can have one of the following values:
+
+* `normal` - regular business, not looping
+* `looping` - run in the loop
+* `exiting` - final run of teardown when exiting the loop.
+
+
+.. code-block:: python
+
+    from nose.core import NOSE
+
+    selenium_process = None
+
+    def setup_package():
+        global selenium_process
+
+        # Don't start selenium if it is already started.
+        if selenium_process:
+            return
+
+        selenium_path = os.path.join(
+            selenium_standalone.MODULE_PATH,
+            'selenium-server-standalone.jar',
+            )
+        command = ['java', '-jar', selenium_path]
+        with open(os.devnull, 'w') as devnull:
+            selenium_process = subprocess.Popen(
+                command,
+                stderr=subprocess.STDOUT,
+                stdout=devnull,
+                )
+
+    def teardown_package():
+        # Don't close selenium when looping tests.
+        if NOSE['state'] == 'looping':
+            return
+
+        os.kill(selenium_process.pid, signal.SIGKILL)
+"""
+from nose.plugins.base import Plugin
+
+
+class LoopPlugin(Plugin):
+    """
+    Simple loop plugin.
+    """
+    name = 'loop'


### PR DESCRIPTION
Problem description
===================

This is an experimental usage of nose test runner.

Karma Test Runner from JS has a nice feature which allows continuously running the tests.
The idea is that you run tests in a loop and test runner waits for changes in the test files, reload them and re-run the tests.

I have a Python backed project, but it has a web fronted which is implemented in JS and for which we run Selenium tests.

Starting and stopping selenium is slow, and starting browsers is also slow, so we tried to keep selenium running together with a browser instance.

I know that sharing fixtures is a bad think, but when creating a fixtures takes 5 seconds you don't have other options (ex starting Chrome or IE browser in Selenium)

This is only a prototype to experiment with the idea of continuous tests.

This does not work for Python Code TDD since only tests are reloaded, but it works for testing the JS code since the browser will reload the JS code.

This  code should not land in master as it is just here to discuss the main feature of looping tests.


Changes description
===================

All tests are run in a loop which can be interrupted by CTRL+C.

There is a NOSE shared variable which informs tests the current state of 

At exit the teardown is called one more time so that you can clean the test fixtures that you want to persist durring the loop.

It waits 1 seconds and then check if tests files were modified, reload all tests and rerun them.

The wait is stupid and reload only tests files as a proof of concept.

There is a simple Plugin which is used to add the `--with-loop` configuration option.


How to try and test the changes
===============================

Enable LoopPlugin and run tests with `--with-loop`.

Change a test file and wait for test runner to automatically re-run it.

Let me know if you find this feature useful and are interested in changing nose to support it.

It does not require to be included in upstream node and the only required change is to move the following lines in a separate method

```
        result = self.testRunner.run(self.test)
        self.success = result.wasSuccessful()
```

In this way, the TestProgram can be extend and implement various running strategies.

Thanks!