### PR TITLE
Instruct coverage instance to cover requested packages only.

### DIFF
--- a/nose/plugins/cover.py
+++ b/nose/plugins/cover.py
@@ -140,7 +140,8 @@ class Coverage(Plugin):
         if self.enabled:
             self.status['active'] = True
             self.coverInstance = coverage.coverage(auto_data=False,
-                branch=self.coverBranches, data_suffix=None)
+                branch=self.coverBranches, data_suffix=None,
+                source=self.coverPackages)
 
     def begin(self):
         """


### PR DESCRIPTION
When `--cover-package=blah` is specified at the command line, the package is not passed to the coverage instance.    So even though the coverage report will only include the `blah` package, the `.coverage` file written will still contain coverage information for packages other than `blah`.  This is important if you are using `coveralls` and do not have a `.coveragerc` file in the directory where `nosetests` is run.
