### PR TITLE
Rename NOSE_WITH_DOCTEST => NOSE_WITH_DOCTESTS in documentation.

### DIFF
--- a/nose/plugins/doctests.py
+++ b/nose/plugins/doctests.py
@@ -1,4 +1,4 @@
-"""Use the Doctest plugin with ``--with-doctest`` or the NOSE_WITH_DOCTEST
+"""Use the Doctest plugin with ``--with-doctest`` or the NOSE_WITH_DOCTESTS
 environment variable to enable collection and execution of :mod:`doctests
 <doctest>`.  Because doctests are usually included in the tested package
 (instead of being grouped into packages or modules of their own), nose only


### PR DESCRIPTION
The docs previously said you DOCTEST but should have said DOCTESTS (note plural).

The behaviour is defined in [this source line](https://github.com/nose-devs/nose/blob/release_1.3.0/nose/plugins/base.py#L83) and the fact that the plugin's name is `doctests.py` rather than `doctest.py`
