### PR TITLE
Do not write to self if so configured.

### DIFF
--- a/nose/plugins/xunit.py
+++ b/nose/plugins/xunit.py
@@ -123,7 +123,8 @@ class Tee(object):
     def write(self, data):
         data = force_unicode(data, self._encoding)
         for s in self._streams:
-            s.write(data)
+            if not isinstance(s, Tee):
+                s.write(data)
 
     def writelines(self, lines):
         for line in lines:


### PR DESCRIPTION
Still requires a test but creating a pull-request so I can keep track:

Fixes an issue I've run into locally and seen on the internet a few times:
- http://invenio-software.org/ticket/1618
- http://lists.openstack.org/pipermail/openstack-stable-maint/2013-April/000427.html

I don't quite understand the root cause yet but this fixes the issue.

```
Traceback (most recent call last):
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/src/sterling/sterling/utils/decorators.py", line 20, in wrapped
    return function(*args, **kwargs)
  File "/var/lib/jenkins/jobs/balanced/workspace/balanced_service/messages/__init__.py", line 128, in _publish
    publish(self.exchange, self.key, payload)
  File "/var/lib/jenkins/jobs/balanced/workspace/tests/__init__.py", line 316, in publish
    search.on_ingest(payload)
  File "/var/lib/jenkins/jobs/balanced/workspace/balanced_service/search/__init__.py", line 101, in on_ingest
    v.ingest(obj)
  File "/var/lib/jenkins/jobs/balanced/workspace/balanced_service/search/v2/__init__.py", line 261, in ingest
    doc_type,
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/src/pyes/pyes/es.py", line 969, in index
    return self._send_request(request_method, path, doc, querystring_args)
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/src/pyes/pyes/es.py", line 384, in _send_request
    response = self.connection.execute(request)
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/src/pyes/pyes/connection_http.py", line 99, in execute
    response = conn.urlopen(**kwargs)
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/lib/python2.7/site-packages/urllib3/connectionpool.py", line 541, in urlopen
    body=body, headers=headers)
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/lib/python2.7/site-packages/urllib3/connectionpool.py", line 374, in _make_request
    log.debug("Setting read timeout to %s" % read_timeout)
  File "/usr/local/lib/python2.7/logging/__init__.py", line 1128, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/usr/local/lib/python2.7/logging/__init__.py", line 1258, in _log
    self.handle(record)
  File "/usr/local/lib/python2.7/logging/__init__.py", line 1268, in handle
    self.callHandlers(record)
  File "/usr/local/lib/python2.7/logging/__init__.py", line 1308, in callHandlers
    hdlr.handle(record)
  File "/usr/local/lib/python2.7/logging/__init__.py", line 748, in handle
    self.emit(record)
  File "/usr/local/lib/python2.7/logging/__init__.py", line 874, in emit
    self.handleError(record)
  File "/usr/local/lib/python2.7/logging/__init__.py", line 801, in handleError
    None, sys.stderr)
  File "/usr/local/lib/python2.7/traceback.py", line 124, in print_exception
    _print(file, 'Traceback (most recent call last):')
  File "/usr/local/lib/python2.7/traceback.py", line 13, in _print
    file.write(str+terminator)
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/lib/python2.7/site-packages/nose/plugins/xunit.py", line 136, in write
    s.write(*args)
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/lib/python2.7/site-packages/nose/plugins/xunit.py", line 136, in write
    s.write(*args)
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/lib/python2.7/site-packages/nose/plugins/xunit.py", line 136, in write
    s.write(*args)
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/lib/python2.7/site-packages/nose/plugins/xunit.py", line 136, in write
    s.write(*args)
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/lib/python2.7/site-packages/nose/plugins/xunit.py", line 136, in write
    s.write(*args)
<snip>
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/lib/python2.7/site-packages/nose/plugins/xunit.py", line 136, in write
    s.write(*args)
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/lib/python2.7/site-packages/nose/plugins/xunit.py", line 136, in write
    s.write(*args)
  File "/var/lib/jenkins/jobs/balanced/workspace/.pyenv/lib/python2.7/site-packages/nose/plugins/xunit.py", line 136, in write
    s.write(*args)
RuntimeError: maximum recursion depth exceeded
```
