### PR TITLE
Added --gentests option to specify which tests generated by a generator to run

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -515,10 +515,10 @@ class Config(object):
         parser.add_option(
             "--gentests", action="store", dest="generatorTests", default=None,
             metavar='NAMES',
-            help="Rung these generated tests (comma-separated list). This argument is "
+            help="Run generated tests that match this regular expression. This argument is "
             "useful mainly from configuration files; on the command line, "
-            "just pass the names of generated tests to run as additional arguments with no "
-            "switch.")
+            "just pass regular expression that should match the generated tests "
+            "to run as additional arguments with no switch.")
         parser.add_option(
             "-l", "--debug", action="store",
             dest="debug", default=self.debug,

--- a/nose/loader.py
+++ b/nose/loader.py
@@ -13,6 +13,7 @@ import os
 import sys
 import unittest
 import types
+import re
 from inspect import isfunction
 from nose.pyversion import unbound_method, ismethod
 from nose.case import FunctionTestCase, MethodTestCase
@@ -250,7 +251,11 @@ class TestLoader(unittest.TestLoader):
             try:
                 for test in g():
                     test_func, arg = self.parseGeneratedTest(test)
-                    if self.config.generatorTests and test_func.description not in self.config.generatorTests:
+                    try:
+                        if self.config.generatorTests and \
+                           not any([re.match(i,test_func.description) for i in self.config.generatorTests]):
+                            continue
+                    except re.error:
                         continue
                     if not callable(test_func):
                         test_func = getattr(m, test_func)


### PR DESCRIPTION
There is no current way to specify which generated tests to run.
If the generated tests have a proper description field that specify a simple compact name for each generated 
test case. Then you can use the --gentests field to specify a list of comma separated names that match the 
generated test names.
