### PR TITLE
Provide unittest2 assert macros in nose.tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
   - pypy
 install:
   - pip uninstall -y nose
-  - pip install -r requirements.txt --use-mirrors
+  - pip install --use-mirrors "coverage >= 3.3"
+  - if [ "$TRAVIS_PYTHON_VERSION" == "2.5" ] || [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then
+    pip install --use-mirrors unittest2; fi;
 script:
   - python setup.py build_tests || python setup.py egg_info; python selftest.py

--- a/doc/testing_tools.rst
+++ b/doc/testing_tools.rst
@@ -7,5 +7,11 @@ and testing for exceptions, and all of the same assertX methods found
 in `unittest.TestCase` (only spelled in :pep:`8#function-names`
 fashion, so `assert_equal` rather than `assertEqual`).
 
+Under Python older than 2.7 unittest2_ will be used instead to provide
+backported unittest_ 2.7+ assert macros.
+
+.. _unittest2: https://pypi.python.org/pypi/unittest2
+.. _unittest: http://docs.python.org/2/library/unittest.html
+
 .. automodule :: nose.tools
    :members:

--- a/nose/tools/trivial.py
+++ b/nose/tools/trivial.py
@@ -6,7 +6,10 @@ methods in ``unittest`` proper.
 
 """
 import re
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 
 __all__ = ['ok_', 'eq_']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# note that this is currently only used for travis-ci
-coverage>=3.3

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ if sys.version_info >= (3,):
              'test_build_dir': 'build/tests',
              'pyversion_patching': True,
              }
+elif sys.version_info < (2, 6):
+    extra = {'install_requires': ['unittest2']}
 else:
     extra = {}
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist=py33,py32,py31,py27,py26,py25,py24,jython,docs
 
 [testenv]
 deps= coverage >=3.3
+      unittest2
 commands=
   python selftest.py []
 
@@ -45,12 +46,14 @@ commands=
   {envpython} selftest.py []
 
 [testenv:py32]
+deps= coverage >=3.3
 commands=
   rm -fr {toxinidir}/build
   {envpython} setup.py build_tests
   {envpython} selftest.py []
 
 [testenv:py33]
+deps= coverage >=3.3
 commands=
   rm -fr {toxinidir}/build
   {envpython} setup.py build_tests

--- a/unit_tests/test_tools.py
+++ b/unit_tests/test_tools.py
@@ -171,6 +171,13 @@ class TestTools(unittest.TestCase):
         if compat_24:
             assert 'assert_true' in tc_asserts
 
+        # make sure we support backported unittest features
+        try:
+            with nose.tools.assert_raises(KeyError):
+                raise KeyError
+        except Exception:
+            self.fail('assert_raises not working as context manager')
+
     def test_multiple_with_setup(self):
         from nose.tools import with_setup
         from nose.case import FunctionTestCase


### PR DESCRIPTION
There are several useful assertX macros in 2.7+ unittest.TestCase, I think it'd be nice to have them in nose.tools at the expense of unittest2 dependency in case of Python < 2.7.