### PR TITLE
Fix the test failures in issue 759.

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -623,9 +623,6 @@ class NoOptions(object):
     def __getnewargs__(self):
         return ()
 
-    def __getattr__(self, attr):
-        return None
-
     def __nonzero__(self):
         return False
 

--- a/nose/suite.py
+++ b/nose/suite.py
@@ -573,6 +573,7 @@ class FinalizingSuiteWrapper(unittest.TestSuite):
     control.
     """
     def __init__(self, suite, finalize):
+        super(FinalizingSuiteWrapper, self).__init__()
         self.suite = suite
         self.finalize = finalize
 


### PR DESCRIPTION
This fixes the two test failures in issue 759 for me.  I'm not sure commenting out `NoOptions.__getattr__()` is the right thing to do, but it works for me and doesn't introduce any new test failures.
