### PR TITLE
Add note about tests being ignored from +x files.

### DIFF
--- a/nose/usage.txt
+++ b/nose/usage.txt
@@ -17,6 +17,11 @@ may use the assert keyword or raise AssertionErrors to indicate test
 failure. TestCase subclasses may do the same or use the various
 TestCase methods available.
 
+**It is important to note that the default behavior of nose is to 
+not include tests from files which are executable.**  To include
+tests from such files, remove their executable bit and/or use 
+the --exe flag (see 'Options' section below).
+
 Selecting Tests
 ---------------
 


### PR DESCRIPTION
I've had this problem numerous times and I know others have too.  While the documentation does mention this under the --exe flag, it makes sense to put it here since this is where people are going to look first when they run into issues.
