### PR TITLE
setup.py: Don't create man files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,6 @@ setup(
     license = 'GNU LGPL',
     keywords = 'test unittest doctest automatic discovery',
     url = 'http://readthedocs.org/docs/nose/',
-    data_files = [('man/man1', ['nosetests.1'])],
     package_data = {'': ['*.txt',
                          'examples/*.py',
                          'examples/*/*.py']},


### PR DESCRIPTION
GitHub Issue #731 explains an error that does not allow nose to be installed
globally to a device. Although it was determined that this error might be due
to setuptools (or derivates), it was not fixed yet and the fundamental problem
remains that nose is not installable in a system global context without
virtualenvs.

Therefore this commit removes setup.py's ability to create manual files under
the assumption that most people using virtualenv will not use the man file but
instead refer to the web documentation anyway. Thus most people should not even
realise the missing man files, while in exchange people can now install nose
without virtualenvs.

Signed-off-by: Erik Bernoth erik.bernoth@gmail.com
