### PR TITLE
Adds unittest's "fail" function to nose.tools.

### DIFF
--- a/nose/tools/trivial.py
+++ b/nose/tools/trivial.py
@@ -44,7 +44,7 @@ class Dummy(unittest.TestCase):
 _t = Dummy('nop')
 
 for at in [ at for at in dir(_t)
-            if at.startswith('assert') and not '_' in at ]:
+            if at.startswith('assert') and not '_' in at ] + ['fail']:
     pepd = pep8(at)
     vars()[pepd] = getattr(_t, at)
     __all__.append(pepd)


### PR DESCRIPTION
With all the `assert_*` helpers, I was expecting to find `fail` there, too! I figure that if it's worthwhile having `ok`, it's worth having `fail`. :)

http://nose.readthedocs.org/en/latest/testing_tools.html?highlight=eq_#nose.tools.ok_

Thanks!
