### PR TITLE
capturedOutput attribute to be initialize to None in nose.suite.ContextSuite

### DIFF
--- a/nose/suite.py
+++ b/nose/suite.py
@@ -154,6 +154,7 @@ class ContextSuite(LazySuite):
         self.has_run = False
         self.can_split = can_split
         self.error_context = None
+        self.capturedOutput = None
         LazySuite.__init__(self, tests)
 
     def __repr__(self):


### PR DESCRIPTION
same as it is done in nose.case.Test to avoid break in failure in module / class setup or teardown when using --nocapture option.