### PR TITLE
Make issue680 test succeed with LC_ALL=C

### DIFF
--- a/functional_tests/test_xunit.py
+++ b/functional_tests/test_xunit.py
@@ -86,8 +86,8 @@ class TestIssue680(PluginTester, unittest.TestCase):
 
     def runTest(self):
         print str(self.output)
-        f = open(xml_results_filename,'r')
-        result = f.read()
+        f = open(xml_results_filename,'rb')
+        result = f.read().decode('utf-8')
         f.close()
         print result
         assert 'tests="1" errors="0" failures="0" skip="0"' in result


### PR DESCRIPTION
Previously, it was failing with:

nose.proxy.UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2
in position 189: ordinal not in range(128)

Thanks to @warsaw for reporting the issue.
