### PR TITLE
Fix #711 and #506: ContextSuite is being passed to addError()

### DIFF
--- a/functional_tests/test_plugins.py
+++ b/functional_tests/test_plugins.py
@@ -27,19 +27,18 @@ class TestPluginCalls(unittest.TestCase):
         assert man.called
 
         self.assertEqual(
-            man.calls(),
             ['loadPlugins', 'addOptions', 'configure', 'begin',
              'prepareTestLoader', 'loadTestsFromNames', 'loadTestsFromName',
              'prepareTestRunner', 'prepareTest', 'setOutputStream',
-             'prepareTestResult', 'beforeDirectory', 'wantFile',
-             'wantDirectory', 'beforeContext', 'beforeImport',
-             'afterImport', 'wantModule', 'wantClass', 'wantFunction',
-             'makeTest', 'wantMethod', 'loadTestsFromTestClass',
+             'beforeDirectory', 'wantFile', 'wantDirectory', 'beforeContext',
+             'beforeImport', 'afterImport', 'wantModule', 'wantClass',
+             'wantFunction', 'makeTest', 'wantMethod', 'loadTestsFromTestClass',
              'loadTestsFromTestCase', 'loadTestsFromModule', 'startContext',
-             'beforeTest', 'prepareTestCase', 'startTest', 'addSuccess',
-             'stopTest', 'afterTest', 'stopContext', 'afterContext',
-             'loadTestsFromDir', 'afterDirectory',
-             'report', 'finalize'])
+             'prepareTestResult', 'beforeTest', 'prepareTestCase', 'startTest',
+             'addSuccess', 'stopTest', 'afterTest', 'stopContext',
+             'afterContext', 'loadTestsFromDir', 'afterDirectory',
+             'report', 'finalize'],
+            man.calls())
 
     def test_plugin_calls_package1_verbose(self):
         wdir = os.path.join(support, 'package1')
@@ -51,19 +50,18 @@ class TestPluginCalls(unittest.TestCase):
         assert man.called
 
         self.assertEqual(
-            man.calls(),
             ['loadPlugins', 'addOptions', 'configure', 'begin',
              'prepareTestLoader', 'loadTestsFromNames', 'loadTestsFromName',
              'prepareTestRunner', 'prepareTest', 'setOutputStream',
-             'prepareTestResult', 'beforeDirectory', 'wantFile',
-             'wantDirectory', 'beforeContext', 'beforeImport',
-             'afterImport', 'wantModule', 'wantClass', 'wantFunction',
-             'makeTest', 'wantMethod', 'loadTestsFromTestClass',
+             'beforeDirectory', 'wantFile', 'wantDirectory', 'beforeContext',
+             'beforeImport', 'afterImport', 'wantModule', 'wantClass',
+             'wantFunction', 'makeTest', 'wantMethod', 'loadTestsFromTestClass',
              'loadTestsFromTestCase', 'loadTestsFromModule', 'startContext',
-             'beforeTest', 'prepareTestCase', 'startTest', 'describeTest',
-             'testName', 'addSuccess', 'stopTest', 'afterTest', 'stopContext',
-             'afterContext', 'loadTestsFromDir', 'afterDirectory',
-             'report', 'finalize'])
+             'prepareTestResult', 'beforeTest', 'prepareTestCase', 'startTest',
+             'describeTest', 'testName', 'addSuccess', 'stopTest', 'afterTest',
+             'stopContext', 'afterContext', 'loadTestsFromDir',
+             'afterDirectory', 'report', 'finalize'],
+            man.calls())
 
 
 

--- a/nose/suite.py
+++ b/nose/suite.py
@@ -117,6 +117,30 @@ class LazySuite(unittest.TestSuite):
                       "generator, so iteration may not be repeatable.")
 
 
+class ErrorHolder(Test):
+    def __init__(self, test, description):
+        super(ErrorHolder, self).__init__(test)
+        self.description = description
+
+    def run(self, result):
+        pass
+
+    def __call__(self, result):
+        return self.run(result)
+
+    def runTest(self, result):
+        return self.run(result)
+
+    def id(self):
+        return self.description
+
+    def shortDescription(self):
+        return None
+
+    def __str__(self):
+        return self.id()
+
+
 class ContextSuite(LazySuite):
     """A suite with context.
 
@@ -193,24 +217,61 @@ class ContextSuite(LazySuite):
 
         return e
 
+    def _determineSetupRoutine(self):
+        context = self.context
+        if isclass(context):
+            names = self.classSetup
+        else:
+            names = self.moduleSetup
+            if hasattr(context, '__path__'):
+                names = self.packageSetup + names
+        for name in names:
+            func = getattr(context, name, None)
+            if callable(func):
+                return func
+        return self.setUp
+
+    def _determineTeardownRoutine(self):
+        context = self.context
+        if isclass(context):
+            names = self.classTeardown
+        else:
+            names = self.moduleTeardown
+            if hasattr(context, '__path__'):
+                names = self.packageTeardown + names
+        for name in names:
+            func = getattr(context, name, None)
+            if callable(func):
+                return func
+        return self.tearDown
+
+    def _getName(self, obj):
+        return getattr(obj, '__name__', str(obj))
+
     def run(self, result):
         """Run tests in suite inside of suite fixtures.
         """
-        # proxy the result for myself
         log.debug("suite %s (%s) run called, tests: %s", id(self), self, self._tests)
-        #import pdb
-        #pdb.set_trace()
-        if self.resultProxy:
-            result, orig = self.resultProxy(result, self), result
-        else:
-            result, orig = result, result
+
+        # This here just in case an error occurs during the class/module level
+        # setup and teardown.  We'll use them to help formulate a useful error
+        # message to the user.
+        setupRoutine = self._determineSetupRoutine()
+        teardownRoutine = self._determineTeardownRoutine()
+
         try:
             self.setUp()
         except KeyboardInterrupt:
             raise
         except:
             self.error_context = 'setup'
-            result.addError(self, self._exc_info())
+            testCaseSetup = ErrorHolder(
+                    setupRoutine, '%s:%s' % (
+                        self._getName(self.context),
+                        self._getName(setupRoutine)))
+            if self.resultProxy:
+                result = self.resultProxy(result, testCaseSetup)
+            result.addError(testCaseSetup, self._exc_info())
             return
         try:
             for test in self._tests:
@@ -220,7 +281,7 @@ class ContextSuite(LazySuite):
                 # each nose.case.Test will create its own result proxy
                 # so the cases need the original result, to avoid proxy
                 # chains
-                test(orig)
+                test(result)
         finally:
             self.has_run = True
             try:
@@ -229,7 +290,13 @@ class ContextSuite(LazySuite):
                 raise
             except:
                 self.error_context = 'teardown'
-                result.addError(self, self._exc_info())
+                testCaseTeardown = ErrorHolder(
+                        teardownRoutine, '%s:%s' % (
+                            self._getName(self.context),
+                            self._getName(teardownRoutine)))
+                if self.resultProxy:
+                    result = self.resultProxy(result, testCaseTeardown)
+                result.addError(testCaseTeardown, self._exc_info())
 
     def hasFixtures(self, ctx_callback=None):
         context = self.context


### PR DESCRIPTION
The core issue is that when class and module-level setup and teardown
occurs, we have no test case to associate with it.  As a result, the
ContextSuite itself was being passed to addError(), but that's a
violation of the plugin API.  Instead, let's create a Test specifically
for coping with errors in the setup and teardown, and try to scope it to
give user's useful feedback about what failed.

This changed when the prepareTestResult() method is called, so the test
was updated.
