### PR TITLE
Recognize doctest options defined in other plugins.

### DIFF
--- a/nose/plugins/doctests.py
+++ b/nose/plugins/doctests.py
@@ -195,18 +195,19 @@ class Doctest(Plugin):
         if options.doctestOptions:
             flags = ",".join(options.doctestOptions).split(',')
             for flag in flags:
-                try:
-                    if flag.startswith('+'):
-                        self.optionflags |= getattr(doctest, flag[1:])
-                    elif flag.startswith('-'):
-                        self.optionflags &= ~getattr(doctest, flag[1:])
-                    else:
-                        raise ValueError(
-                            "Must specify doctest options with starting " +
-                            "'+' or '-'.  Got %s" % (flag,))
-                except AttributeError:
+                if not flag or flag[0] not in '+-':
+                    raise ValueError(
+                        "Must specify doctest options with starting " +
+                        "'+' or '-'.  Got %s" % (flag,))
+                mode, option_name = flag[0], flag[1:]
+                option_flag = doctest.OPTIONFLAGS_BY_NAME.get(option_name)
+                if not option_flag:
                     raise ValueError("Unknown doctest option %s" %
-                                     (flag[1:],))
+                                     (option_name,))
+                if mode == '+':
+                    self.optionflags |= option_flag
+                elif mode == '-':
+                    self.optionflags &= ~option_flag
 
     def prepareTestLoader(self, loader):
         """Capture loader's suiteClass.


### PR DESCRIPTION
I needed to use the [doctest-ignore-unicode](https://github.com/gnublade/doctest-ignore-unicode) plugin, but found that `--doctest-options='+IGNORE_UNICODE'` would fail.

The problem is that the doctest plugin fetched flags via `getattr(doctest, flagname)` instead of `doctest.OPTIONFLAGS_BY_NAME[flagname]`, which means it won't detect doctest options registered by other plugins.

This patch fixes that.
