### PR TITLE
Fix for try_run when using bound methods

### DIFF
--- a/nose/util.py
+++ b/nose/util.py
@@ -452,7 +452,7 @@ def try_run(obj, names):
                         inspect.getargspec(func)
                 else:
                     # Not a function. If it's callable, call it anyway
-                    if hasattr(func, '__call__'):
+                    if hasattr(func, '__call__') and not inspect.ismethod(func):
                         func = func.__call__
                     try:
                         args, varargs, varkw, defaults = \

--- a/unit_tests/test_utils.py
+++ b/unit_tests/test_utils.py
@@ -170,16 +170,22 @@ class TestUtils(unittest.TestCase):
             def __call__(self, mod):
                 pass
 
+        class Bar_method:
+            def method(self):
+                pass
+
         foo = imp.new_module('foo')
         foo.bar = bar
         foo.bar_m = bar_m
         foo.i_bar = Bar()
         foo.i_bar_m = Bar_m()
+        foo.i_bar_m = Bar_method().method
 
         try_run(foo, ('bar',))
         try_run(foo, ('bar_m',))
         try_run(foo, ('i_bar',))
         try_run(foo, ('i_bar_m',))
+        try_run(foo, ('i_bar_method',))
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In relation to issue #783, which breaks the usage of bound methods as fixtures.
