### PR TITLE
Call super in LazySuite to access _removed_tests variable

### DIFF
--- a/nose/suite.py
+++ b/nose/suite.py
@@ -49,6 +49,7 @@ class LazySuite(unittest.TestSuite):
     def __init__(self, tests=()):
         """Initialize the suite. tests may be an iterable or a generator
         """
+        super(LazySuite, self).__init__()
         self._set_tests(tests)
 
     def __iter__(self):


### PR DESCRIPTION
I have encountered the issue #759 while building billiard with python 3.4, as mentioned in my comment.
