### PR TITLE
Fix coverage plugin with multiprocess plugin

### DIFF
--- a/nose/plugins/cover.py
+++ b/nose/plugins/cover.py
@@ -99,6 +99,7 @@ class Coverage(Plugin):
         except KeyError:
             pass
         super(Coverage, self).configure(options, conf)
+        self.worker = conf.worker
         if conf.worker:
             return
         if self.enabled:
@@ -147,6 +148,8 @@ class Coverage(Plugin):
         """
         Begin recording coverage information.
         """
+        if not self.enabled or self.worker:
+            return
         log.debug("Coverage begin")
         self.skipModules = sys.modules.keys()[:]
         if self.coverErase:
@@ -161,6 +164,8 @@ class Coverage(Plugin):
         """
         Output code coverage report.
         """
+        if not self.enabled or self.worker:
+            return
         log.debug("Coverage report")
         self.coverInstance.stop()
         self.coverInstance.combine()


### PR DESCRIPTION
This properly fixes pull request #710 and similar issues like https://github.com/dvdotsenko/nose_gevent_multiprocess/issues/2
multiprocess plugin tries to configure coverage plugin in each worker process,
thus raising
```
Traceback (most recent call last):
  File "/usr/lib/python3.4/multiprocessing/process.py", line 254, in _bootstrap
    self.run()
  File "/usr/lib/python3.4/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3/dist-packages/nose/plugins/multiprocess.py", line 652, in runner
    keyboardCaught, shouldStop, loaderClass, resultClass, config)
  File "/usr/lib/python3/dist-packages/nose/plugins/multiprocess.py", line 669, in __runner
    config.plugins.begin()
  File "/usr/lib/python3/dist-packages/nose/plugins/manager.py", line 99, in __call__
    return self.call(*arg, **kw)
  File "/usr/lib/python3/dist-packages/nose/plugins/manager.py", line 167, in simple
    result = meth(*arg, **kw)
  File "/usr/lib/python3/dist-packages/nose/plugins/cover.py", line 160, in begin
    self.coverInstance.exclude('#pragma[: ]+[nN][oO] [cC][oO][vV][eE][rR]')
AttributeError: 'NoneType' object has no attribute 'exclude'
```
coverage plugin should be a no-op in worker processes, since Coverage.py
works with multiprocessing out of the box and the support for that was
added to nose in 2010: https://code.google.com/r/arveknudsen-cover-parallel/source/list