### PR TITLE
Show ValueError about -w path name in quotes

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -416,7 +416,7 @@ class Config(object):
             if not self.workingDir:
                 abs_path = absdir(path)
                 if abs_path is None:
-                    raise ValueError("Working directory %s not found, or "
+                    raise ValueError("Working directory '%s' not found, or "
                                      "not a directory" % path)
                 log.info("Set working dir to %s", abs_path)
                 self.workingDir = abs_path


### PR DESCRIPTION
Calling nose with args like `['-w /foo/bar']` cause a ValueError about `Working directory  /foo/bar not found...`. With this patch debugging this issue is much easier. (`Working directory ' /foo/bar' not found...`)
