### PR TITLE
with_setup: let funcs receive arbitrary args and kwargs

### DIFF
--- a/doc/writing_tests.rst
+++ b/doc/writing_tests.rst
@@ -114,6 +114,24 @@ for test methods in `unittest.TestCase` subclasses or other test
 classes. For those cases, define `setUp` and `tearDown` methods in the
 class.
   
+The `with_setup` decorator also supports the ability for the setup function
+to pass objects into the wrapped test function and teardown via `params=True`.
+For example::
+
+  def setup_func():
+      # pass test fixtures directly to functions
+      return ('Blue', 'Muppet!'), {'kw1': 'Hello', 'kw2': 'world'}
+
+  def teardown_func(arg1, kw2):
+      print "Received arg1 and kw2: %s %s" % (arg1, kw2)  # prints Blue world
+
+  @with_setup(setup_func, teardown_func, params=True)
+  def test_me(arg1, arg2, kw1):
+      msg = "%s, %s %s" % (kw1, arg1, arg2)
+      print msg
+      assert msg == "Hello, Blue Muppet!"
+
+
 Test generators
 ===============
 

--- a/nose/tools/nontrivial.py
+++ b/nose/tools/nontrivial.py
@@ -104,7 +104,18 @@ def timed(limit):
     return decorate
 
 
-def with_setup(setup=None, teardown=None):
+def _smart_run(func, args, kwargs):
+    """Given a function definition, determine which of the args and
+    kwargs are relevant and then execute the function"""
+    fc = func.func_code
+    kwargs2 = dict(
+        (k, kwargs[k])
+        for k in kwargs if k in fc.co_varnames[:fc.co_nlocals])
+    args2 = args[:fc.co_nlocals - len(kwargs2)]
+    func(*args2, **kwargs2)
+
+
+def with_setup(setup=None, teardown=None, params=False):
     """Decorator to add setup and/or teardown methods to a test function::
 
       @with_setup(setup, teardown)
@@ -115,25 +126,49 @@ def with_setup(setup=None, teardown=None):
     methods or inside of TestCase subclasses.
     """
     def decorate(func, setup=setup, teardown=teardown):
+        args = []
+        kwargs = {}
+        if params:
+            @make_decorator(func)
+            def func_wrapped():
+                _smart_run(func, args, kwargs)
+        else:
+            func_wrapped = func
         if setup:
+            def setup_wrapped():
+                rv = setup()
+                if rv is not None:
+                    args.extend(rv[0])
+                    kwargs.update(rv[1])
+
             if hasattr(func, 'setup'):
                 _old_s = func.setup
+
                 def _s():
-                    setup()
+                    setup_wrapped()
                     _old_s()
-                func.setup = _s
+                func_wrapped.setup = _s
             else:
-                func.setup = setup
+                if params:
+                    func_wrapped.setup = setup_wrapped
+                else:
+                    func_wrapped.setup = setup
+
         if teardown:
             if hasattr(func, 'teardown'):
                 _old_t = func.teardown
+
                 def _t():
                     _old_t()
-                    teardown()
-                func.teardown = _t
+                    _smart_run(teardown, args, kwargs)
+                func_wrapped.teardown = _t
             else:
-                func.teardown = teardown
-        return func
+                if params:
+                    func_wrapped.teardown = lambda: _smart_run(
+                        teardown, args, kwargs)
+                else:
+                    func_wrapped.teardown = teardown
+        return func_wrapped
     return decorate
 
 

--- a/unit_tests/test_tools.py
+++ b/unit_tests/test_tools.py
@@ -225,5 +225,45 @@ class TestTools(unittest.TestCase):
         self.assertEqual(called, ['s1', 's2', 's3',
                                   'test3', 't3', 't2', 't1'])
 
+    def test_params_with_setup(self):
+        from nose.tools import with_setup
+
+        def setup_func():
+            return ('Blue', 'Muppet!'), {'kw1': 'Hello', 'kw2': 'world'}
+
+        def t1():
+            pass
+
+        def t2(arg2):
+            # arg2 is arg1 in this case
+            assert_equal(arg2, 'Blue')
+
+        def t3(kw2, kw1):
+            assert_equal(kw1, 'Hello')
+            assert_equal(kw2, 'world')
+
+        def t4(arg1, arg2, kw1):
+            assert_equal(arg1, 'Blue')
+            assert_equal(arg2, 'Muppet!')
+            assert_equal(kw1, 'Hello')
+
+
+        def t5(x, y, z):
+            raise Exception('this should not get raised')
+
+        tests = [t1, t2, t3, t4]
+        for teardown_func in tests:
+            for tf in tests:
+                case = with_setup(setup_func, teardown_func, True)(tf)
+                case.setup()
+                case()
+                case.teardown()
+
+            case = with_setup(setup_func, teardown_func, True)(t5)
+            case.setup()
+            raises(TypeError)(case)()
+            case.teardown()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hello,

I created this PR and would love to know if you're interested in merging it.  Here's what I've done:
- Calling `nose.tools.with_setup(..., params=True)` allows the setup() function to return args and kwargs.  The decorated test and teardown functions can use some or all of those args and kwargs as they choose.
- Includes tests and documentation.
- This PR is adapted from this gist: https://gist.github.com/garyvdm/392ae20c673c7ee58d76

For example:

```
    def setup_func():
        return ['arg1', 'arg2'], dict(kw1='kw1', kw2='kw2')

    def teardown_func(arg1, kw2):
        print('teardown received arg1=%s kw2=%s' % (arg1, kw2))

    @nose.tools.with_setup(setup_func, teardown_func, True)
    def test_a(arg1, arg2, kw1):
        print('test_a received %s %s %s' % (arg1, arg2, kw1))

```
