### PR TITLE
[plugins] Handle multiprocess & cover together

### DIFF
--- a/nose/plugins/cover.py
+++ b/nose/plugins/cover.py
@@ -137,11 +137,11 @@ class Coverage(Plugin):
             log.debug('Will put XML coverage report in %s', self.coverXmlFile)
         if self.enabled:
             self.status['active'] = True
-            self.coverInstance.is_worker = conf.worker
             self.coverInstance = coverage.coverage(auto_data=False,
                 branch=self.coverBranches, data_suffix=conf.worker,
                 source=self.coverPackages)
             self.coverInstance._warn_no_data = False
+            self.coverInstance.is_worker = conf.worker
             self.coverInstance.exclude('#pragma[: ]+[nN][oO] [cC][oO][vV][eE][rR]')
 
             log.debug("Coverage begin")

--- a/nose/plugins/cover.py
+++ b/nose/plugins/cover.py
@@ -99,8 +99,6 @@ class Coverage(Plugin):
         except KeyError:
             pass
         super(Coverage, self).configure(options, conf)
-        if conf.worker:
-            return
         if self.enabled:
             try:
                 import coverage
@@ -139,23 +137,43 @@ class Coverage(Plugin):
             log.debug('Will put XML coverage report in %s', self.coverXmlFile)
         if self.enabled:
             self.status['active'] = True
+            self.coverInstance.is_worker = conf.worker
             self.coverInstance = coverage.coverage(auto_data=False,
-                branch=self.coverBranches, data_suffix=None,
+                branch=self.coverBranches, data_suffix=conf.worker,
                 source=self.coverPackages)
+            self.coverInstance._warn_no_data = False
+            self.coverInstance.exclude('#pragma[: ]+[nN][oO] [cC][oO][vV][eE][rR]')
 
-    def begin(self):
+            log.debug("Coverage begin")
+            self.skipModules = sys.modules.keys()[:]
+            if self.coverErase:
+                log.debug("Clearing previously collected coverage statistics")
+                self.coverInstance.combine()
+                self.coverInstance.erase()
+
+            if not self.coverInstance.is_worker:
+                self.coverInstance.load()
+                self.coverInstance.start()
+
+
+    def beforeTest(self, *args, **kwargs):
         """
         Begin recording coverage information.
         """
-        log.debug("Coverage begin")
-        self.skipModules = sys.modules.keys()[:]
-        if self.coverErase:
-            log.debug("Clearing previously collected coverage statistics")
-            self.coverInstance.combine()
-            self.coverInstance.erase()
-        self.coverInstance.exclude('#pragma[: ]+[nN][oO] [cC][oO][vV][eE][rR]')
-        self.coverInstance.load()
-        self.coverInstance.start()
+
+        if self.coverInstance.is_worker:
+            self.coverInstance.load()
+            self.coverInstance.start()
+
+    def afterTest(self, *args, **kwargs):
+        """
+        Stop recording coverage information.
+        """
+
+        if self.coverInstance.is_worker:
+            self.coverInstance.stop()
+            self.coverInstance.save()
+
 
     def report(self, stream):
         """


### PR DESCRIPTION
Addressing issue #820 and #710

I am relying on `coverage`'s own method to run in parallel and store each worker's coverage in a separate .coverage file that gets combined in the `report()` method.