### PR TITLE
Added support for custom TextTestResult class.

### DIFF
--- a/nose/plugins/multiprocess.py
+++ b/nose/plugins/multiprocess.py
@@ -270,7 +270,8 @@ class MultiProcess(Plugin):
         return MultiProcessTestRunner(stream=runner.stream,
                                       verbosity=self.config.verbosity,
                                       config=self.config,
-                                      loaderClass=self.loaderClass)
+                                      loaderClass=self.loaderClass,
+                                      resultclass=runner.resultclass)
 
 def signalhandler(sig, frame):
     raise TimedOutException()


### PR DESCRIPTION
Hello,

This small patch adds support for custom result classes, similarly to how pyut TextTestResult does since 2.7.2.

(Disclaimer: this work was done while at Cisco Systems LTD and all the required authorizations for pushing upstream were obtained through the internal open source patch channel)
