### PR TITLE
Added support for custom separator.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -293,6 +293,13 @@ Options
    Prevent nose from byte-compiling the source into .pyc files while
    nose is scanning for and running tests.
 
+--pyut-style-separator
+
+   Use all-dots (PyUT style) test path separator (eg:
+   module.class.test) instead of the default ':' (eg:
+   dir.file:class.test). NB: this is inteded for use with module names
+   rather than path to files.
+
 -a=ATTR, --attr=ATTR
 
    Run only tests that have attributes specified by ATTR [NOSE_ATTR]

--- a/nose/config.py
+++ b/nose/config.py
@@ -175,6 +175,7 @@ class Config(object):
       self.where = ()
       self.py3where = ()
       self.workingDir = None
+      self.pyutSeparator = False
     """
 
     def __init__(self, **kw):
@@ -215,6 +216,7 @@ class Config(object):
         self.firstPackageWins = False
         self.parserClass = OptionParser
         self.worker = False
+        self.pyutSeparator = False
 
         self._default = self.__dict__.copy()
         self.update(kw)
@@ -317,6 +319,7 @@ class Config(object):
         self.loggingConfig = options.loggingConfig
         self.firstPackageWins = options.firstPackageWins
         self.configureLogging()
+        self.pyutSeparator = options.pyutSeparator
 
         if not options.byteCompile:
             sys.dont_write_bytecode = True
@@ -586,6 +589,13 @@ class Config(object):
             action="store_false", default=True, dest="byteCompile",
             help="Prevent nose from byte-compiling the source into .pyc files "
             "while nose is scanning for and running tests.")
+        parser.add_option(
+            "--pyut-style-separator", action="store_true", default=False,
+            dest="pyutSeparator", metavar='PYUTSEPARATOR',
+            help="Use all-dots (PyUT style) test path separator (eg: "
+            "module.class.test) instead of the default ':' (eg: "
+            "dir.file:class.test). NB: this is inteded for use with module "
+            "names rather than path to files.")
 
         self.plugins.loadPlugins()
         self.pluginOpts(parser)

--- a/nose/loader.py
+++ b/nose/loader.py
@@ -57,7 +57,7 @@ class TestLoader(unittest.TestLoader):
     suiteClass = None
     
     def __init__(self, config=None, importer=None, workingDir=None,
-                 selector=None):
+                 selector=None, pyutSeparator=False):
         """Initialize a test loader.
 
         Parameters (all optional):
@@ -75,6 +75,9 @@ class TestLoader(unittest.TestLoader):
           provided, it will be instantiated with one argument, the
           current config. If not provided, a `nose.selector.Selector`_
           is used.
+        * pyutSeparator: True or False. False will use the default ':' as
+          the character that separates test name parts, True will use '.' like
+          PyUT does.
         """
         if config is None:
             config = Config()
@@ -93,6 +96,10 @@ class TestLoader(unittest.TestLoader):
         if config.addPaths:
             add_path(workingDir, config)        
         self.suiteClass = ContextSuiteFactory(config=config)
+        if pyutSeparator is False:
+            self.pyutSeparator = self.config.pyutSeparator
+        else:
+            self.pyutSeparator = pyutSeparator
 
         self._visitedPaths = set([])
 
@@ -371,7 +378,8 @@ class TestLoader(unittest.TestLoader):
         if plug_tests:
             return suite(plug_tests)
         
-        addr = TestAddress(name, workingDir=self.workingDir)
+        addr = TestAddress(name, workingDir=self.workingDir,
+                           pyutSeparator=self.pyutSeparator)
         if module:
             # Two cases:
             #  name is class.foo

--- a/nose/selector.py
+++ b/nose/selector.py
@@ -218,12 +218,13 @@ class TestAddress(object):
     Callables may be a class name, function name, method name, or
     class.method specification.
     """
-    def __init__(self, name, workingDir=None):
+    def __init__(self, name, workingDir=None, pyutSeparator=False):
         if workingDir is None:
             workingDir = os.getcwd()
         self.name = name
         self.workingDir = workingDir
-        self.filename, self.module, self.call = split_test_name(name)
+        self.filename, self.module, self.call = split_test_name(name,
+                                                                pyutSeparator)
         log.debug('Test name %s resolved to file %s, module %s, call %s',
                   name, self.filename, self.module, self.call)
         if self.filename is None:

--- a/nosetests.1
+++ b/nosetests.1
@@ -310,6 +310,11 @@ Prevent nose from byte\-compiling the source into .pyc files while nose is scann
 .UNINDENT
 .INDENT 0.0
 .TP
+.B \-\-pyut\-style\-separator
+Use all\-dots (PyUT style) test path separator (eg: module.class.test) instead of the default \(aq:\(aq (eg: dir.file:class.test). NB: this is inteded for use with module names rather than path to files.
+.UNINDENT
+.INDENT 0.0
+.TP
 .B \-a=ATTR, \-\-attr=ATTR
 Run only tests that have attributes specified by ATTR [NOSE_ATTR]
 .UNINDENT

--- a/unit_tests/test_utils.py
+++ b/unit_tests/test_utils.py
@@ -36,6 +36,21 @@ class TestUtils(unittest.TestCase):
         assert split_test_name('foo:bar/baz.py') == \
             (np('foo:bar/baz.py'), None, None)
 
+    def test_split_test_name_pyut_separator(self):
+        split_test_name = util.split_test_name
+        assert split_test_name('nose.util.Some.method', True) == \
+            (None, 'nose.util', 'Some.method')
+        assert split_test_name('nose.util', True) == \
+            (None, 'nose.util', None)
+        assert split_test_name('some/file.py', True) == \
+            (np('some/file.py'), None, None)
+        assert split_test_name('.Baz', True) == \
+            (None, None, 'Baz')
+        assert split_test_name('foo.bar/baz.py', True) == \
+            (np('foo.bar/baz.py'), None, None)
+        assert split_test_name(r'c:/some/other/path.py', True) == \
+            (np(r'c:/some/other/path.py'), None, None)
+
     def test_split_test_name_windows(self):
         # convenience
         stn = util.split_test_name


### PR DESCRIPTION
Hello,

This patch adds support for a custom separator for the test path other than the default ":", configurable by the user through a new option, creatively called "separator" :-)

(Disclaimer: this work was done while at Cisco Systems LTD and all the required authorizations for pushing upstream were obtained through the internal open source patch channel)
