### PR TITLE
Added MultiProcess plugin API for registering callbacks to be run at sta...

### DIFF
--- a/unit_tests/test_multiprocess.py
+++ b/unit_tests/test_multiprocess.py
@@ -1,6 +1,7 @@
 import pickle
 import sys
 import unittest
+import os
 
 from nose import case
 from nose.plugins import multiprocess
@@ -12,6 +13,12 @@ try:
     from unittest.runner import _WritelnDecorator
 except ImportError:
     from unittest import _WritelnDecorator
+from warnings import warn
+try:
+    from multiprocessing import Manager
+except ImportError:
+    warn("multiprocessing module is not available, multiprocess plugin "
+         "cannot be used", RuntimeWarning)
 
 
 class ArgChecker:
@@ -60,3 +67,76 @@ def test_mp_process_args_pickleable():
         config=config)
     runner.run(test)
         
+
+def add_pid_callback(pid_list):
+    pid_list.append(os.getpid())
+
+
+def check_pid_callback(pid_list):
+    assert len(pid_list) > 0
+    assert os.getpid() in pid_list
+
+
+def del_pid_callback(pid_list):
+    pid_list.remove(os.getpid())
+
+
+def test_mp_process_callbacks_register_first():
+    """Register callbacks first and then create Config. The startup callback
+    adds the PID on a shared list, and the stop callbacks respectively
+    check if the PID is there and then delete it."""
+
+    manager = Manager()
+    pid_list = manager.list()
+
+    opts = type('options', (object,), {'multiprocess_workers': 2,
+                                       'multiprocess_timeout': 5,
+                                       'multiprocess_restartworker': False})
+    mp_plugin = multiprocess.MultiProcess()
+    mp_plugin.register_start_callback(add_pid_callback, pid_list)
+    # We add a second one, so that we can check at the end that len(list) == 2
+    mp_plugin.register_start_callback(add_pid_callback, pid_list)
+    mp_plugin.register_stop_callback(check_pid_callback, pid_list)
+    mp_plugin.register_stop_callback(del_pid_callback, pid_list)
+    mp_plugin.configure(opts, Config())
+
+    test = case.Test(T('runTest'))
+    runner = multiprocess.MultiProcessTestRunner(
+                stream=_WritelnDecorator(sys.stdout),
+                verbosity=10,
+                loaderClass=TestLoader,
+                config=mp_plugin.config)
+    runner.run(test)
+
+    assert len(pid_list) == 2
+
+
+def test_mp_process_callbacks_config_first():
+    """Create Config first and then register callbacks. The startup callback
+    adds the PID on a shared list, and the stop callbacks respectively
+    check if the PID is there and then delete it."""
+
+    manager = Manager()
+    pid_list = manager.list()
+
+    opts = type('options', (object,), {'multiprocess_workers': 2,
+                                       'multiprocess_timeout': 5,
+                                       'multiprocess_restartworker': False})
+    mp_plugin = multiprocess.MultiProcess()
+    mp_plugin.configure(opts, Config())
+    mp_plugin.register_start_callback(add_pid_callback, pid_list)
+    # We add a second one, so that we can check at the end that len(list) == 2
+    mp_plugin.register_start_callback(add_pid_callback, pid_list)
+    mp_plugin.register_stop_callback(check_pid_callback, pid_list)
+    mp_plugin.register_stop_callback(del_pid_callback, pid_list)
+
+    test = case.Test(T('runTest'))
+    runner = multiprocess.MultiProcessTestRunner(
+                stream=_WritelnDecorator(sys.stdout),
+                verbosity=10,
+                loaderClass=TestLoader,
+                config=mp_plugin.config)
+    runner.run(test)
+
+    assert len(pid_list) == 2
+


### PR DESCRIPTION
Hello,

This patch adds support for MultiProcess plugin worker processes to execute callbacks at start and/or stop. The callbacks can be registered (including args) via two new APIs.

The use-case we had was some worker-specific setup requirement which was very slow and error prone, and we wanted to have some resilience in case one failed. The normal test class setUp() could not be used effectively because it is executed when the worker already pulled a test from the Queue, which means in case of catastrophic failure that test would be lost. But thanks to this callback, if a worker process dies horribly the others can carry on and all the tests are run.

(Disclaimer: this work was done while at Cisco Systems LTD and all the required authorizations for pushing upstream were obtained through the internal open source patch channel)
