### PR TITLE
Allow attribute plugin to select for match on method or class

### DIFF
--- a/functional_tests/support/att/test_attr.py
+++ b/functional_tests/support/att/test_attr.py
@@ -95,12 +95,22 @@ def added_later_test(self):
 
 TestAttrSubClass.added_later_test = added_later_test
 
-class TestIterAttr(object):
+class TestClassAndMethodIterAttr(object):
     foo = [ 'a' ]
 
     def test_one(self):
         pass
     test_one.foo = [ 'b' ]
+
+    def test_two(self):
+        pass
+
+class TestClassAndMethodStrAttr(object):
+    foo = 'a'
+
+    def test_one(self):
+        pass
+    test_one.foo = 'b'
 
     def test_two(self):
         pass

--- a/functional_tests/test_attribute_plugin.py
+++ b/functional_tests/test_attribute_plugin.py
@@ -180,14 +180,16 @@ class TestStaticMethod(AttributePluginTester):
         assert 'Ran 1 test' in self.output
 
 
-class TestIterClassAttribute(AttributePluginTester):
+class TestClassAndMethodAttribute(AttributePluginTester):
     '''Test extension of iterable class and method attributes'''
     args = ["-a", "foo=a,foo=b"]
 
     def verify(self):
-        assert 'TestIterAttr.test_one ... ok' in self.output
-        assert 'TestIterAttr.test_two ... ok' not in self.output
-        assert 'Ran 1 test' in self.output
+        assert 'TestClassAndMethodIterAttr.test_one ... ok' in self.output
+        assert 'TestClassAndMethodIterAttr.test_two ... ok' not in self.output
+        assert 'TestClassAndMethodStrAttr.test_one ... ok' in self.output
+        assert 'TestClassAndMethodStrAttr.test_two ... ok' not in self.output
+        assert 'Ran 2 tests' in self.output
 
 
 if compat_24:

--- a/nose/plugins/attrib.py
+++ b/nose/plugins/attrib.py
@@ -133,10 +133,15 @@ def get_method_attr(method, cls, attr_name, default = False):
     """
     Missing = object()
     value = getattr(method, attr_name, Missing)
-    if type(value) in (tuple, list) and cls is not None:
-        cls_value = getattr(cls, attr_name, None)
-        if type(cls_value) in (tuple, list):
-            value = list(value) + list(cls_value)
+    if value is not Missing and not isinstance(value, bool) \
+            and cls is not None:
+        cls_value = getattr(cls, attr_name, Missing)
+        if cls_value is not Missing and not isinstance(cls_value, bool):
+            if not isinstance(value, (tuple, list)):
+                value = [value]
+            if not isinstance(cls_value, (tuple, list)):
+                cls_value = [cls_value]
+            value = value + cls_value
     elif value is Missing and cls is not None:
         value = getattr(cls, attr_name, Missing)
     if value is Missing:

--- a/unit_tests/test_plugins.py
+++ b/unit_tests/test_plugins.py
@@ -282,7 +282,7 @@ class TestAttribPlugin(unittest.TestCase):
         assert plug.wantFunction(i) is False
         
 
-    def test_iter_attr(self):
+    def test_class_and_method_iter_attr(self):
         class TestP(object):
             foo = ['a']
 
@@ -302,6 +302,29 @@ class TestAttribPlugin(unittest.TestCase):
         plug.attribs = [[('foo', 'b')]]
         assert plug.wantMethod(unbound_method(TestP, TestP.h)) is not False
         assert plug.wantFunction(i) is False
+
+
+    def test_class_and_method_str_attr(self):
+        class TestP(object):
+            foo = 'a'
+
+            def h(self):
+                pass
+            h.foo = 'b'
+
+        def i():
+            pass
+        i.foo = 'a'
+
+        plug = AttributeSelector()
+        plug.attribs = [[('foo', 'a'), ('foo', 'b')]]
+        assert plug.wantMethod(unbound_method(TestP, TestP.h)) is not False
+        assert plug.wantFunction(i) is False
+
+        plug.attribs = [[('foo', 'b')]]
+        assert plug.wantMethod(unbound_method(TestP, TestP.h)) is not False
+        assert plug.wantFunction(i) is False
+
 
     def test_eval_attr(self):
         if not compat_24:


### PR DESCRIPTION
For non `bool` attributes, it's desirable to combine attributes specified at the class level and the method level, rather than to treat the method attribute as an override to the class attribute. For instance, we use attribute tagging to relate tests back to issues in Jira, and you frequently find yourself in a situation where you want to do something like this:

```
from nose.plugins.attrib import attr

@attr(issue="#123")
class TestFeatureFoo(object):
    def test__core_feature(self):
        pass

    @attr(issue="#789")
    def test__bug_789(self):
        pass
```

With these tests, I would like the test runner:

```
nosetests -a issue=#123
```

To pick up both tests, but as currently implemented, only `test__core_feature` would be run. With this patch the same test runner would pick up both `test__core_feature` and `test__bug_789`, which is preferable.
