### PR TITLE
Fix #879: setuptools command ignores NOSE_IGNORE_CONFIG_FILES option

### DIFF
--- a/functional_tests/support/issue879/nose.cfg
+++ b/functional_tests/support/issue879/nose.cfg
@@ -1,0 +1,2 @@
+[nosetests]
+fail = true

--- a/functional_tests/support/issue879/setup.py
+++ b/functional_tests/support/issue879/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup
+
+setup(
+    name='issue879',
+    setup_requires=['nose'],
+    test_suite='nose.collector'
+)

--- a/functional_tests/test_issue_879.py
+++ b/functional_tests/test_issue_879.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import unittest
+from subprocess import PIPE, Popen
+
+import nose
+from nose.plugins.skip import SkipTest
+
+
+support = os.path.join(os.path.dirname(__file__), 'support', 'issue879')
+
+class TestIssue879(unittest.TestCase):
+    def setUp(self):
+        try:
+            import setuptools
+        except ImportError:
+            raise SkipTest("setuptools not available")
+        os.chdir(support)
+
+    def test_command_can_ignore_user_config_files(self):
+        pythonpath = os.path.normpath(os.path.join(
+            os.path.abspath(os.path.dirname(nose.__file__)),
+            '..'))
+
+        env = {
+            'HOME': support,
+            'PYTHONPATH': pythonpath
+            }
+        process = Popen(
+            [sys.executable, 'setup.py', 'nosetests'],
+            stdout=PIPE, stderr=PIPE, env=env)
+        out, err = process.communicate()
+        retcode = process.poll()
+        self.assertNotEqual(retcode, 0)
+        err = err.decode(sys.stderr.encoding)
+        self.assertTrue("no such option 'fail'" in err)
+
+        env = {
+            'HOME': support,
+            'PYTHONPATH': pythonpath,
+            'NOSE_IGNORE_CONFIG_FILES': '1'
+            }
+        process = Popen(
+            [sys.executable, 'setup.py', 'nosetests'],
+            stdout=PIPE, stderr=PIPE, env=env)
+        out, err = process.communicate()
+        retcode = process.poll()
+        self.assertEqual(retcode, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/nose/commands.py
+++ b/nose/commands.py
@@ -64,6 +64,7 @@ try:
 except ImportError:
     Command = nosetests = None
 else:
+    import os
     from nose.config import Config, option_blacklist, user_config_files, \
         flag, _bool
     from nose.core import TestProgram
@@ -86,9 +87,16 @@ else:
         return opt_list
 
 
+    def get_user_config_files():
+        if os.environ.get('NOSE_IGNORE_CONFIG_FILES', False):
+            return []
+        else:
+            return user_config_files()
+
+
     class nosetests(Command):
         description = "Run unit tests using nosetests"
-        __config = Config(files=user_config_files(),
+        __config = Config(files=get_user_config_files(),
                           plugins=DefaultPluginManager())
         __parser = __config.getParser()
         user_options = get_user_options(__parser)


### PR DESCRIPTION
When the NOSE_IGNORE_CONFIG_FILES environment variable is set, the setuptools command should disable configuration file loading.

The setuptools command would not check the value of the NOSE_IGNORE_CONFIG_FILES environment variable before finding the list of available user configuration files. The direct nosetests command supports this feature. This adds an helper function that checks for the environment variable before getting the list of configuration files.

Fixes https://github.com/nose-devs/nose/issues/879
