### PR TITLE
Fix #131 - use os.stat to check if file is executable

### DIFF
--- a/nose/selector.py
+++ b/nose/selector.py
@@ -8,6 +8,7 @@ thinks may be a test.
 """
 import logging
 import os
+import stat
 import unittest
 from nose.config import Config
 from nose.util import split_test_name, src, getfilename, getpackage, ispackage
@@ -120,7 +121,14 @@ class Selector(object):
             log.debug('%s matches ignoreFiles pattern; skipped',
                       base) 
             return False
-        if not self.config.includeExe and os.access(file, os.X_OK):
+
+        def is_executable(file):
+            if not os.path.exists(file):
+                return False
+            st = os.stat(file)
+            return bool(st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+        if not self.config.includeExe and is_executable(file):
             log.info('%s is executable; skipped', file)
             return False
         dummy, ext = op_splitext(base)

--- a/nose/selector.py
+++ b/nose/selector.py
@@ -8,10 +8,9 @@ thinks may be a test.
 """
 import logging
 import os
-import stat
 import unittest
 from nose.config import Config
-from nose.util import split_test_name, src, getfilename, getpackage, ispackage
+from nose.util import split_test_name, src, getfilename, getpackage, ispackage, is_executable
 
 log = logging.getLogger(__name__)
 
@@ -121,13 +120,6 @@ class Selector(object):
             log.debug('%s matches ignoreFiles pattern; skipped',
                       base) 
             return False
-
-        def is_executable(file):
-            if not os.path.exists(file):
-                return False
-            st = os.stat(file)
-            return bool(st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
-
         if not self.config.includeExe and is_executable(file):
             log.info('%s is executable; skipped', file)
             return False

--- a/nose/util.py
+++ b/nose/util.py
@@ -3,6 +3,7 @@
 import inspect
 import itertools
 import logging
+import stat
 import os
 import re
 import sys
@@ -654,7 +655,14 @@ def safe_str(val, encoding='utf-8'):
                              for arg in val])
         return unicode(val).encode(encoding)
 
-    
+
+def is_executable(file):
+    if not os.path.exists(file):
+        return False
+    st = os.stat(file)
+    return bool(st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod()


### PR DESCRIPTION
this is similar to #522 but with @jszakmeister comment fixed (which addresses @adiroiban's concerns).
no need for a test case because the existing tests already cover this (the tests simply don't run on AIX without this). Tests pass on AIX with this.