### PR TITLE
Add --always-succeed option

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -293,6 +293,10 @@ Options
    Prevent nose from byte-compiling the source into .pyc files while
    nose is scanning for and running tests.
 
+--always-succeed
+
+   Return a success exit code even if tests failed
+
 -a=ATTR, --attr=ATTR
 
    Run only tests that have attributes specified by ATTR [NOSE_ATTR]

--- a/nose/config.py
+++ b/nose/config.py
@@ -215,6 +215,7 @@ class Config(object):
         self.firstPackageWins = False
         self.parserClass = OptionParser
         self.worker = False
+        self.alwaysSucceed = False
 
         self._default = self.__dict__.copy()
         self.update(kw)
@@ -340,6 +341,9 @@ class Config(object):
         if options.exclude:
             self.exclude = map(re.compile, tolist(options.exclude))
             log.info("Excluding tests matching %s", options.exclude)
+
+        if options.alwaysSucceed:
+            self.alwaysSucceed = options.alwaysSucceed
 
         # When listing plugins we don't want to run them
         if not options.showPlugins:
@@ -586,6 +590,10 @@ class Config(object):
             action="store_false", default=True, dest="byteCompile",
             help="Prevent nose from byte-compiling the source into .pyc files "
             "while nose is scanning for and running tests.")
+        parser.add_option(
+            "--always-succeed",
+            action="store_true", default=False, dest="alwaysSucceed",
+            help="Return a success exit code even if tests failed")
 
         self.plugins.loadPlugins()
         self.pluginOpts(parser)

--- a/nose/core.py
+++ b/nose/core.py
@@ -205,7 +205,7 @@ class TestProgram(unittest.TestProgram):
         if plug_runner is not None:
             self.testRunner = plug_runner
         result = self.testRunner.run(self.test)
-        self.success = result.wasSuccessful()
+        self.success = result.wasSuccessful() or self.config.alwaysSucceed
         if self.exit:
             sys.exit(not self.success)
         return self.success

--- a/nosetests.1
+++ b/nosetests.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "NOSETESTS" "1" "April 04, 2015" "1.3" "nose"
+.TH "NOSETESTS" "1" "May 07, 2015" "1.3" "nose"
 .SH NAME
 nosetests \- Nicer testing for Python
 .
@@ -307,6 +307,11 @@ nose\(aqs importer will normally evict a package from sys.modules if it sees a p
 .TP
 .B \-\-no\-byte\-compile
 Prevent nose from byte\-compiling the source into .pyc files while nose is scanning for and running tests.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-always\-succeed
+Return a success exit code even if tests failed
 .UNINDENT
 .INDENT 0.0
 .TP


### PR DESCRIPTION
I have a build processes that needs the test run to be successful even if tests failed. Our internal test driver provides a --always-succeed option to support this case. I'm trying to integrate nosetests as an alternative for some projects, and need this functionality. 

I was unable to find any place where nose tests currently check exit status, so it wasn't clear how and where to test this feature. 