### PR TITLE
work around deadlock reported in #921

### DIFF
--- a/nose/importer.py
+++ b/nose/importer.py
@@ -73,7 +73,8 @@ class Importer(object):
             else:
                 part_fqname = "%s.%s" % (part_fqname, part)
             try:
-                acquire_lock()
+                if sys.version_info < (3, 4):
+                    acquire_lock()
                 log.debug("find module part %s (%s) in %s",
                           part, part_fqname, path)
                 fh, filename, desc = find_module(part, path)
@@ -83,9 +84,9 @@ class Importer(object):
                     # we get a fresh copy of anything we are trying to load
                     # from a new path
                     log.debug("sys.modules has %s as %s", part_fqname, old)
-                    if (self.sameModule(old, filename)
-                        or (self.config.firstPackageWins and
-                            getattr(old, '__path__', None))):
+                    if (self.sameModule(old, filename) or
+                            (self.config.firstPackageWins and
+                             getattr(old, '__path__', None))):
                         mod = old
                     else:
                         del sys.modules[part_fqname]
@@ -95,7 +96,8 @@ class Importer(object):
             finally:
                 if fh:
                     fh.close()
-                release_lock()
+                if sys.version_info < (3, 4):
+                    release_lock()
             if parent:
                 setattr(parent, part, mod)
             if hasattr(mod, '__path__'):
@@ -145,10 +147,10 @@ def add_path(path, config=None):
         return []
     added = []
     parent = os.path.dirname(path)
-    if (parent
-        and os.path.exists(os.path.join(path, '__init__.py'))):
+    if (parent and
+            os.path.exists(os.path.join(path, '__init__.py'))):
         added.extend(add_path(parent, config))
-    elif not path in sys.path:
+    elif path not in sys.path:
         log.debug("insert %s into sys.path", path)
         sys.path.insert(0, path)
         added.append(path)

--- a/unit_tests/test_issue_921.py
+++ b/unit_tests/test_issue_921.py
@@ -1,0 +1,10 @@
+import multiprocessing
+
+manager = multiprocessing.Manager()
+lock = manager.Lock()
+dict_ = manager.dict()
+
+
+def test_multiprocessing():
+    "Test that the import machinery doesn't get locked by the manager"
+    pass

--- a/unit_tests/test_issue_921.rst
+++ b/unit_tests/test_issue_921.rst
@@ -1,0 +1,12 @@
+In python 3.4, a lot of the :mod:`imp` machinery has been rewritten. In
+particular, the part that actually imports the module now acquire and release
+the global import lock, so an explicit lock in
+:meth:`nose.importer.Importer.importFromDir` is not needed and it's likely the
+source of the deadlock reported in issue #921. This happen when a lock is
+created somewhere at the module level or as static property of a class. E.g.::
+
+  import multiprocessing
+
+  manager = multiprocessing.Manager()
+  lock = manager.Lock()
+  dict_ = manager.dict()


### PR DESCRIPTION
This commit hopefully solves issue #921.
I've added a null test, that should deadlock nose in case the fix doesn't work.

Both ``selftest.py`` and ``run_tests.sh``, with python 3.4 and 2.7, work.

Let's see what Travis says

ps: there a few PEP8 fixes