### PR TITLE
fix 3rd party plugin override builtin plugin

### DIFF
--- a/nose/plugins/manager.py
+++ b/nose/plugins/manager.py
@@ -416,7 +416,7 @@ class BuiltinPluginManager(PluginManager):
 
 try:
     import pkg_resources
-    class DefaultPluginManager(EntryPointPluginManager, BuiltinPluginManager):
+    class DefaultPluginManager(BuiltinPluginManager, EntryPointPluginManager):
         pass
 
 except ImportError:


### PR DESCRIPTION
http://nose.readthedocs.org/en/latest/plugins/builtin.html

As written in docs, we should load builtin plugins first and entry point second to override builtin

This ability was added on Jan 20, 2010 in https://github.com/nose-devs/nose/commit/b9644d9ae1835a50d989869c8a54de73551f3f6b#diff-2e123b55b4ea7e3f48cf733fd7925e2bR250
and was broken on Nov 12, 2011 in https://github.com/nose-devs/nose/commit/0300f58e1ccc12fde9e4046dcbd469dde5e7c8f9#diff-2e123b55b4ea7e3f48cf733fd7925e2bR419