### PR TITLE
nose/suite: mixedSuites: avoid no-op makeSuite

### DIFF
--- a/nose/suite.py
+++ b/nose/suite.py
@@ -530,7 +530,7 @@ class ContextSuiteFactory(object):
                             break
                     if not found_common:
                         remain.append(test)
-                if common:
+                if len(common) > 1:
                     suite = self.makeSuite(common, ancestor)
                 tail = self.mixedSuites(remain)
         return [suite] + tail


### PR DESCRIPTION
Hi,

 This patch reduces the depth of the suite tree created by mixedSuites, tested on our internal 1000 tests suite. Before and after tree height:

$ cat mixed_suite_results__after_patch.txt | grep -oE '^ *' | sort | uniq | tail -1 | wc -c
22
$ cat mixed_suite_results__before_patch.txt | grep -oE '^ *' | sort | uniq | tail -1 | wc -c
168

The text files were produced with this function run at `TestProgram.__init__` after `self.parseArgs`

    show_suite_tree(self.test, '/tmp/after_mixed_suite.txt')
    
    def show_suite_tree(suite, filename, level=0):
        with open(filename, 'w+') as fd:
            show_suite_tree__helper(suite, fd, level)
   
    def show_suite_tree__helper(suite, fd, level):
        fd.write(('{}{}\n'.format(level * ' ', repr(suite))))
        try:
            for test in suite._tests:
                show_suite_tree__helper(test, fd, level + 1)
        except:
            pass
