### PR TITLE
BUG: Tee doesn't have encoding or errors attrs.

### DIFF
--- a/nose/plugins/xunit.py
+++ b/nose/plugins/xunit.py
@@ -120,11 +120,12 @@ def exc_message(exc_info):
 
 class Tee(object):
     def __init__(self, encoding, *args):
-        self._encoding = encoding
+        self.encoding = encoding
         self._streams = args
+        self.errors = None
 
     def write(self, data):
-        data = force_unicode(data, self._encoding)
+        data = force_unicode(data, self.encoding)
         for s in self._streams:
             s.write(data)
 

--- a/unit_tests/test_xunit.py
+++ b/unit_tests/test_xunit.py
@@ -8,7 +8,7 @@ from xml.sax import saxutils
 
 from nose.pyversion import UNICODE_STRINGS
 from nose.tools import eq_
-from nose.plugins.xunit import Xunit, escape_cdata, id_split
+from nose.plugins.xunit import Xunit, escape_cdata, id_split, Tee
 from nose.exc import SkipTest
 from nose.config import Config
 
@@ -67,11 +67,29 @@ class TestOptions(unittest.TestCase):
         (options, args) = parser.parse_args(["--xunit-file=blagojevich.xml"])
         eq_(options.xunit_file, "blagojevich.xml")
 
+class TestTee(unittest.TestCase):
+    def setUp(self):
+        self.orig_stderr = sys.stderr
+        sys.stderr = Tee('utf-8', self.orig_stderr)
+
+    def tearDown(self):
+        sys.stderr = self.orig_stderr
+
+    def test_tee_has_error_and_encoding_attributes(self):
+        tee = Tee('utf-8', sys.stdout)
+        self.assertTrue(hasattr(tee, 'encoding'))
+        self.assertTrue(hasattr(tee, 'errors'))
+
+    def test_tee_works_with_distutils_log(self):
+        from distutils.log import Log, DEBUG
+        l = Log(DEBUG)
+        l.warn('Test')
+
 class TestXMLOutputWithXML(unittest.TestCase):
 
     def setUp(self):
         self.xmlfile = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), 
+            os.path.join(os.path.dirname(__file__),
                             'support', 'xunit.xml'))
         parser = optparse.OptionParser()
         self.x = Xunit()
@@ -215,7 +233,7 @@ class TestXMLOutputWithXML(unittest.TestCase):
         test = mktest()
         self.x.beforeTest(test)
         try:
-            raise RuntimeError(chr(128)) # cannot encode as utf8 
+            raise RuntimeError(chr(128)) # cannot encode as utf8
         except RuntimeError:
             some_err = sys.exc_info()
         self.x.addError(test, some_err)
@@ -309,4 +327,3 @@ class TestXMLOutputWithXML(unittest.TestCase):
             assert '<?xml version="1.0" encoding="UTF-8"?>' in result
             assert ('<testcase classname="test_xunit.TC" '
                     'name="runTest" time="0') in result
-


### PR DESCRIPTION
On Python3, `distutils.log` uses the encoding and errors attribute of
sys.stdout and stderr.  Tests error out when nose is run with xunit and
it replaces the stdout/stderr with a Tee.

The tests in this PR are rudimentary and only fix the problem I was facing.