### PR TITLE
Fix logcapture plugin to capture output from non-propagating loggers,…

### DIFF
--- a/nose/plugins/logcapture.py
+++ b/nose/plugins/logcapture.py
@@ -194,6 +194,13 @@ class LogCapture(Plugin):
             if isinstance(handler, MyMemoryHandler):
                 root_logger.handlers.remove(handler)
         root_logger.addHandler(self.handler)
+        # Also patch any non-propagating loggers in the tree
+        for logger in logging.Logger.manager.loggerDict.values():
+            if not getattr(logger, 'propagate', True) and hasattr(logger, "addHandler"):
+                for handler in logger.handlers[:]:
+                    if isinstance(handler, MyMemoryHandler):
+                        logger.handlers.remove(handler)
+                logger.addHandler(self.handler)
         # to make sure everything gets captured
         loglevel = getattr(self, "loglevel", "NOTSET")
         root_logger.setLevel(getattr(logging, loglevel))

--- a/unit_tests/test_logcapture_plugin.py
+++ b/unit_tests/test_logcapture_plugin.py
@@ -255,3 +255,21 @@ class TestLogCapturePlugin(object):
             assert msg in ev
         else:
             assert msg.encode('utf-8') in ev
+
+    def test_non_propagating_loggers_handled(self):
+        c = LogCapture()
+        parser = OptionParser()
+        c.addOptions(parser, {})
+        options, args = parser.parse_args([])
+        c.configure(options, Config())
+
+        logger = logging.getLogger('foo.yes')
+        logger.propagate = False
+
+        c.start()
+        logger.debug("test message")
+        c.end()
+
+        records = c.formatLogRecords()
+        eq_(1, len(records))
+        assert records[0].startswith('foo.yes:'), records[0]


### PR DESCRIPTION
… and to not output 'no handlers could be found' message.

Found this when activating log capturing on my project's test suite, we would end up with a single message in the test output such as `No handlers could be found for logger "foo.yes"` for a logger that has `propagate = False`. This is because the logcapture plugin would clear the handlers and not replace them.

`logging` emits this message once per program: https://hg.python.org/cpython/file/2.7/Lib/logging/__init__.py#l1339

To fix this, I install the memory handler for every non-propagating logger (have to take care to find only legitimate loggers with `propagate = False` and not e.g. `Placeholder` objects). This not only stops the message from appearing but also captures their output which may help further with debugging.