### PR TITLE
detect whether nose was launched via multiprocess

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -175,6 +175,7 @@ class Config(object):
       self.where = ()
       self.py3where = ()
       self.workingDir = None
+      self.is_subprocess = False
     """
 
     def __init__(self, **kw):
@@ -215,6 +216,7 @@ class Config(object):
         self.firstPackageWins = False
         self.parserClass = OptionParser
         self.worker = False
+        self.is_subprocess = False
 
         self._default = self.__dict__.copy()
         self.update(kw)

--- a/nose/plugins/multiprocess.py
+++ b/nose/plugins/multiprocess.py
@@ -326,6 +326,8 @@ class MultiProcessTestRunner(TextTestRunner):
         currentaddr = Value('c',bytes_(''))
         currentstart = Value('d',time.time())
         keyboardCaught = Event()
+        is_subprocess = self.config.is_subprocess
+        self.config.is_subprocess = True
         p = Process(target=runner,
                    args=(iworker, testQueue,
                          resultQueue,
@@ -336,6 +338,7 @@ class MultiProcessTestRunner(TextTestRunner):
                          self.loaderClass,
                          result.__class__,
                          pickle.dumps(self.config)))
+        self.config.is_subprocess = is_subprocess
         p.currentaddr = currentaddr
         p.currentstart = currentstart
         p.keyboardCaught = keyboardCaught


### PR DESCRIPTION
I suppose it's a good idea to know whether nose was launched as subprocess via multiprocess or no. For ex. I need that knowledge in plugin [allure-nose-adaptor](https://github.com/allure-framework/allure-nose-adaptor).