### PR TITLE
[fix travis] Coverage 4.0 is available and is not supported in python 3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 # note that this is currently only used for travis-ci
-coverage>=3.3
+coverage>=3.3; python_version < '3.2'
+coverage>=3.3; python_version > '3.2'
+coverage>=3.3,<4.0; python_version == '3.2'

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ whitelist_externals=
   make
 
 [testenv]
-deps= coverage >= 3.3
+deps=
+  py{26,27,31,33,34}: coverage >= 3.3
+  py32: coverage >= 3.3, <4.0
 commands=
   python selftest.py []
 


### PR DESCRIPTION
Travis tests are failing for the python 3.2 environment (only) with the following traceback.

Coverage 4.0 was also released recently, and is not supported in python 3.2 (see comments [here](https://bitbucket.org/ned/coveragepy/issues/407/coverage-failing-on-python-325-using))


```
......................Exception AssertionError: AssertionError('can only test a child process',) in <Finalize object, dead> ignored
Exception AssertionError: AssertionError('can only test a child process',) in <Finalize object, dead> ignored
Exception AssertionError: AssertionError('can only test a child process',) in <Finalize object, dead> ignored
Exception AssertionError: AssertionError('can only test a child process',) in <Finalize object, dead> ignored
Exception AssertionError: AssertionError('can only test a child process',) in <Finalize object, dead> ignored
Exception AssertionError: AssertionError('can only test a child process',) in <Finalize object, dead> ignored
Exception AssertionError: AssertionError('can only test a child process',) in <Finalize object, dead> ignored
Exception AssertionError: AssertionError('can only test a child process',) in <Finalize object, dead> ignored
Exception AssertionError: AssertionError('can only test a child process',) in <Finalize object, dead> ignored
........................E......................................................................................S...S.......................................nose.plugins.cover: ERROR: Coverage not available: unable to import coverage module
nose.plugins.cover: ERROR: Coverage not available: unable to import coverage module
................................................S..............................................................................SSSS..................................................SS......................
======================================================================
ERROR: Failure: SyntaxError (invalid syntax (annotate.py, line 81))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/benpatterson/nose/build/tests/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/home/travis/build/benpatterson/nose/build/tests/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/travis/build/benpatterson/nose/build/tests/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/travis/build/benpatterson/nose/build/tests/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/travis/build/benpatterson/nose/build/tests/functional_tests/test_coverage_plugin.py", line 14, in <module>
    import coverage
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/coverage/__init__.py", line 13, in <module>
    from coverage.control import Coverage, process_startup
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/coverage/control.py", line 14, in <module>
    from coverage.annotate import AnnotateReporter
  File "/home/travis/virtualenv/python3.2.5/lib/python3.2/site-packages/coverage/annotate.py", line 81
    dest.write(u'  ')
                   ^
SyntaxError: invalid syntax
----------------------------------------------------------------------
Ran 382 tests in 16.717s
FAILED (SKIP=9, errors=1)
```