### PR TITLE
Fix #931: duplicate __init__ modules can be picked up

### DIFF
--- a/functional_tests/test_loader.py
+++ b/functional_tests/test_loader.py
@@ -5,6 +5,7 @@ from difflib import ndiff
 from cStringIO import StringIO
 
 from nose.config import Config
+from nose.plugins.allmodules import AllModules
 from nose.plugins.manager import PluginManager
 from nose.plugins.skip import Skip
 from nose import loader
@@ -64,9 +65,11 @@ class TestNoseTestLoader(unittest.TestCase):
         self.assertEqual(res.testsRun, 1)
 
     def test_fixture_context(self):
+        config = Config(ignoreFiles=[],
+                        plugins=PluginManager(plugins=[AllModules()]))
         res = unittest.TestResult()
         wd = os.path.join(support, 'package2')
-        l = loader.TestLoader(workingDir=wd)
+        l = loader.TestLoader(config=config, workingDir=wd)
         dir_suite = l.loadTestsFromName('.')
         dir_suite(res)
 

--- a/nose/loader.py
+++ b/nose/loader.py
@@ -21,7 +21,7 @@ from nose.config import Config
 from nose.importer import Importer, add_path, remove_path
 from nose.selector import defaultSelector, TestAddress
 from nose.util import func_lineno, getpackage, isclass, isgenerator, \
-    ispackage, regex_last_key, resolve_name, transplant_func, \
+    ispackage, regex_last_key, resolve_name, src, transplant_func, \
     transplant_class, test_address
 from nose.suite import ContextSuiteFactory, ContextList, LazySuite
 from nose.pyversion import sort_list, cmp_to_key
@@ -152,6 +152,8 @@ class TestLoader(unittest.TestLoader):
             # this hard-coded initial-dot test will be removed:
             # http://code.google.com/p/python-nose/issues/detail?id=82
             if entry.startswith('.'):
+                continue
+            if src(entry) == '__init__.py':
                 continue
             entry_path = op_abspath(op_join(path, entry))
             is_file = op_isfile(entry_path)


### PR DESCRIPTION
The short form here is that when setting up ignores, you may allow
__init__.py to be included unexpectedly.  Since we generally use
loadTestsFromName(), the package should be imported first which will
handle the __init__.py case.  Therefore, let's always ignore it in the
loadTestsFromDir() method.  Just to make sure that we ignore the correct
files, we need to run the entry name through src() to make sure we
handle the situation correctly on other platforms (like Jython).