### PR TITLE
nose/case.py: make output more friendly

### DIFF
--- a/functional_tests/doc_tests/test_issue145/imported_tests.rst
+++ b/functional_tests/doc_tests/test_issue145/imported_tests.rst
@@ -43,11 +43,11 @@ imported, not the source modules.
     >>> run(argv=argv) # doctest: +REPORT_NDIFF
     package1 setup
     test (package1.test_module.TestCase) ... ok
-    package1.test_module.TestClass.test_class ... ok
+    package1.test_module:TestClass.test_class ... ok
     package1.test_module.test_function ... ok
     package2c setup
     test (package2c.test_module.TestCase) ... ok
-    package2c.test_module.TestClass.test_class ... ok
+    package2c.test_module:TestClass.test_class ... ok
     package2f setup
     package2f.test_module.test_function ... ok
     <BLANKLINE>
@@ -72,7 +72,7 @@ packages are executed.
     >>> run(argv=argv) # doctest: +REPORT_NDIFF
     package2c setup
     test (package2c.test_module.TestCase) ... ok
-    package2c.test_module.TestClass.test_class ... ok
+    package2c.test_module:TestClass.test_class ... ok
     <BLANKLINE>
     ----------------------------------------------------------------------
     Ran 2 tests in ...s
@@ -87,7 +87,7 @@ command-line.
     ...         ':TestClass.test_class']
     >>> run(argv=argv) # doctest: +REPORT_NDIFF
     package2c setup
-    package2c.test_module.TestClass.test_class ... ok
+    package2c.test_module:TestClass.test_class ... ok
     <BLANKLINE>
     ----------------------------------------------------------------------
     Ran 1 test in ...s

--- a/functional_tests/doc_tests/test_multiprocess/multiprocess.rst
+++ b/functional_tests/doc_tests/test_multiprocess/multiprocess.rst
@@ -135,7 +135,7 @@ The module with shared fixtures passes.
 
     >>> run(argv=['nosetests', '-v', test_shared]) #doctest: +REPORT_NDIFF
     setup called
-    test_shared.TestMe.test_one ... ok
+    test_shared:TestMe.test_one ... ok
     test_shared.test_a ... ok
     test_shared.test_b ... ok
     teardown called
@@ -149,7 +149,7 @@ As does the module with no fixture annotations.
 
     >>> run(argv=['nosetests', '-v', test_not_shared]) #doctest: +REPORT_NDIFF
     setup called
-    test_not_shared.TestMe.test_one ... ok
+    test_not_shared:TestMe.test_one ... ok
     test_not_shared.test_a ... ok
     test_not_shared.test_b ... ok
     teardown called
@@ -163,7 +163,7 @@ And the module that marks its fixtures as re-entrant.
 
     >>> run(argv=['nosetests', '-v', test_can_split]) #doctest: +REPORT_NDIFF
     setup called
-    test_can_split.TestMe.test_one ... ok
+    test_can_split:TestMe.test_one ... ok
     test_can_split.test_a ... ok
     test_can_split.test_b ... ok
     teardown called

--- a/functional_tests/test_attribute_plugin.py
+++ b/functional_tests/test_attribute_plugin.py
@@ -176,7 +176,7 @@ class TestStaticMethod(AttributePluginTester):
     args = ["-a", "!slow"]
 
     def verify(self):
-        assert 'test.TestAttrib.test_static ... ok' in self.output
+        assert 'test:TestAttrib.test_static ... ok' in self.output
         assert 'Ran 1 test' in self.output
 
 

--- a/nose/case.py
+++ b/nose/case.py
@@ -354,7 +354,7 @@ class MethodTestCase(TestBase):
             name = func.compat_func_name
         else:
             name = func.__name__
-        name = "%s.%s.%s" % (self.cls.__module__,
+        name = "%s:%s.%s" % (self.cls.__module__,
                              self.cls.__name__,
                              name)
         if arg:

--- a/unit_tests/test_issue_006.py
+++ b/unit_tests/test_issue_006.py
@@ -15,12 +15,12 @@ class TestIssue006(unittest.TestCase):
 
         testcase = iter(testmod).next()
         expect = [
-            ['tests.Test1.test_nested_generator'],
-            ['tests.Test1.test_nested_generator_mult(1,)',
-             'tests.Test1.test_nested_generator_mult(2,)',
-             'tests.Test1.test_nested_generator_mult(3,)'],
-            ['tests.Test1.test_normal_generator(1,)',
-             'tests.Test1.test_normal_generator(2,)']
+            ['tests:Test1.test_nested_generator'],
+            ['tests:Test1.test_nested_generator_mult(1,)',
+             'tests:Test1.test_nested_generator_mult(2,)',
+             'tests:Test1.test_nested_generator_mult(3,)'],
+            ['tests:Test1.test_normal_generator(1,)',
+             'tests:Test1.test_normal_generator(2,)']
             ]
         for test in testcase:
             tests = map(str, test)


### PR DESCRIPTION
Current 'FAIL:' output uses '.' to separate module, class, and function
names.  This commit changes the '.' before the class to be a ':', which
produces output matching the format expected on the command line when
specifying which test to run.  Modified unittest accordingly.

This allows for easy copy and paste on the command line.

old output:
FAIL: test_example_function.TestExampleFunction.test_times_two

new output:
FAIL: test_example_function:TestExampleFunction.test_times_two