### PR TITLE
Correction for function names matches

### DIFF
--- a/nose/selector.py
+++ b/nose/selector.py
@@ -50,7 +50,7 @@ class Selector(object):
         To match, a name must match config.testMatch OR config.include
         and it must not match config.exclude
         """
-        return ((self.match.search(name)
+        return ((self.match.match(name)
                  or (self.include and
                      filter(None,
                             [inc.search(name) for inc in self.include])))


### PR DESCRIPTION
If use self.match.match,  functions such as build_test or load_tests or other will be included into the tests.
In the result we have a lot of error tests.

May be it is only in my case, than it need ignore proposal.