### PR TITLE
Use a new test loader for each queue item.

### DIFF
--- a/nose/plugins/multiprocess.py
+++ b/nose/plugins/multiprocess.py
@@ -668,8 +668,6 @@ def __runner(ix, testQueue, resultQueue, currentaddr, currentstart,
     config.plugins.configure(config.options,config)
     config.plugins.begin()
     log.debug("Worker %s executing, pid=%d", ix,os.getpid())
-    loader = loaderClass(config=config)
-    loader.suiteClass.suiteClass = NoSharedFixtureContextSuite
 
     def get():
         return testQueue.get(timeout=config.multiprocess_timeout)
@@ -702,6 +700,8 @@ def __runner(ix, testQueue, resultQueue, currentaddr, currentstart,
             log.exception('Worker %d STOPPED',ix)
             break
         result = makeResult()
+        loader = loaderClass(config=config)
+        loader.suiteClass.suiteClass = NoSharedFixtureContextSuite
         test = loader.loadTestsFromNames([test_addr])
         test.testQueue = testQueue
         test.tasks = []


### PR DESCRIPTION
This fixes a memory "leak" that eventually caused the kernel's OOM killer to terminate a worker process.

The loader's ContextSuiteFactory keeps a reference to all of the test suites, even after they've been run, which consumes more and more memory over time.

This change creates a new loader for each suite that's dispatched to the worker, which allows the GC to free the old test suites.

**Note:** I don't understand the worker code well enough to be super confident that this is the right fix, so I'm open to feedback.