### PR TITLE
timed() now enforces time limit.

### DIFF
--- a/unit_tests/test_tools.py
+++ b/unit_tests/test_tools.py
@@ -91,8 +91,9 @@ class TestTools(unittest.TestCase):
         def check_result():
             return 42
         check_result = timed(.2)(check_result)
+        result = check_result()
 
-        assert 42 == check_result()
+        assert 42 == result, result
 
         quick()
         try:


### PR DESCRIPTION
The timed() decorator used to wait indefinitely for its test function to return. Now it runs the test function in a new thread, and if the function doesn't return within the specified time limit, it throws a TimeExpired error.