### PR TITLE
Make tests work with Python ≥ 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - 3.5
   - pypy
 install:
   - pip uninstall -y nose

--- a/functional_tests/test_load_tests_from_test_case.py
+++ b/functional_tests/test_load_tests_from_test_case.py
@@ -29,6 +29,7 @@ class NoFixturePlug(Plugin):
                 pass
             def tearDown(self):
                 pass
+        Derived.__qualname__ = Derived.__name__
         # must use nose loader here because the default loader in 2.3
         # won't load tests from base classes
         l = loader.TestLoader()

--- a/nose/util.py
+++ b/nose/util.py
@@ -643,6 +643,7 @@ def transplant_class(cls, module):
         pass
     C.__module__ = module
     C.__name__ = cls.__name__
+    C.__qualname__ = cls.__name__
     return C
 
 

--- a/unit_tests/test_xunit.py
+++ b/unit_tests/test_xunit.py
@@ -16,6 +16,7 @@ def mktest():
     class TC(unittest.TestCase):
         def runTest(self):
             pass
+    TC.__qualname__ = TC.__name__
     test = TC()
     return test
 


### PR DESCRIPTION
Use `startswith`/`endswith` instead of strict matching on class names.

Also, in unit_tests/test_xunit.py, drop support for Python ≤ 2.4 which did not have ElementTree.

This fixes #928.