### PR TITLE
Allow Travis to install requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - 3.4
   - 3.5
   - pypy
-install:
+cache: pip
+before_install:
   - pip uninstall -y nose
-  - pip install -r requirements.txt --use-mirrors
 script:
   - python setup.py build_tests || python setup.py egg_info; python selftest.py


### PR DESCRIPTION
The pip --use-mirrors option was deprecated in version 1.5, and removed
in 7.0, and 7.1.2 is now included with Travis' Python 3.5.0 environment.

Travis automatically installs packages in requirements.txt
if stage `install` does not exist, and can cache the packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nose-devs/nose/994)
<!-- Reviewable:end -->
