### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/doc/rtd-requirements.txt
+++ b/doc/rtd-requirements.txt
@@ -1,3 +1,3 @@
 # requirements file for Read The Docs
-# http://readthedocs.org/docs/nose/
+# https://nose.readthedocs.io/en/latest/
 sphinx>=1.0

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     coverage and profiling, flexible attribute-based test selection,
     output capture and more. More information about writing plugins may be
     found on in the nose API documentation, here:
-    http://readthedocs.org/docs/nose/
+    https://nose.readthedocs.io/
 
     If you have recently reported a bug marked as fixed, or have a craving for
     the very latest, you may want the development version instead:
@@ -105,7 +105,7 @@ setup(
     """,
     license = 'GNU LGPL',
     keywords = 'test unittest doctest automatic discovery',
-    url = 'http://readthedocs.org/docs/nose/',
+    url = 'https://nose.readthedocs.io/',
     data_files = [('man/man1', ['nosetests.1'])],
     package_data = {'': ['*.txt',
                          'examples/*.py',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
