### PR TITLE
Make coverage plugin compatible with Coverage.py 4.1

### DIFF
--- a/nose/plugins/cover.py
+++ b/nose/plugins/cover.py
@@ -202,7 +202,7 @@ class Coverage(Plugin):
                    if self.wantModuleCoverage(name, module)]
         log.debug("Coverage report will cover modules: %s", modules)
         if self.coverPrint:
-            self.coverInstance.report(modules, file=stream)
+            self.coverInstance.report(modules, file=stream, show_missing=True)
 
         import coverage
         if self.coverHtmlDir:
@@ -222,7 +222,7 @@ class Coverage(Plugin):
         # make sure we have minimum required coverage
         if self.coverMinPercentage:
             f = StringIO.StringIO()
-            self.coverInstance.report(modules, file=f)
+            self.coverInstance.report(modules, file=f, show_missing=True)
 
             multiPackageRe = (r'-------\s\w+\s+\d+\s+\d+(?:\s+\d+\s+\d+)?'
                               r'\s+(\d+)%\s+\d*\s{0,1}$')


### PR DESCRIPTION
According to the Coverage.py 4.1 changelog:
- The `Coverage.report` function had two parameters with non-None defaults,
  which have been changed.  `show_missing` used to default to True, but now
  defaults to None.  If you had been calling `Coverage.report` without
  specifying `show_missing`, you'll need to explicitly set it to True to keep
  the same behavior.

Without that option, four tests in nose fail:
- test_coverage_plugin.TestCoverageMinPercentagePlugin
- test_coverage_plugin.TestCoverageMinPercentageSinglePackagePlugin
- test_coverage_plugin.TestCoverageMinPercentageSinglePackageWithBranchesPlugin
- test_coverage_plugin.TestCoveragePlugin

The example of the failure can be seen in https://bugs.debian.org/828224.
