### PR TITLE
Fix warnings when run with python -3

### DIFF
--- a/nose/pyversion.py
+++ b/nose/pyversion.py
@@ -56,7 +56,7 @@ def cmp_to_key(mycmp):
         def __eq__(self, other):
             return mycmp(self.obj, other.obj) == 0
         def __hash__(self):
-            return obj.__hash__()
+            return hash(obj)
     return Key
 
 # Python 2.3 also does not support list-sorting by key, so we need to convert

--- a/nose/pyversion.py
+++ b/nose/pyversion.py
@@ -55,6 +55,8 @@ def cmp_to_key(mycmp):
             return mycmp(self.obj, other.obj) > 0
         def __eq__(self, other):
             return mycmp(self.obj, other.obj) == 0
+        def __hash__(self):
+            return obj.__hash__()
     return Key
 
 # Python 2.3 also does not support list-sorting by key, so we need to convert

--- a/unit_tests/mock.py
+++ b/unit_tests/mock.py
@@ -92,7 +92,7 @@ class Bucket(object):
         self.__dict__['d'].update(kw)
         
     def __getattr__(self, attr):
-        if not self.__dict__.has_key('d'):
+        if not 'd' in self.__dict__:
             return None
         return self.__dict__['d'].get(attr)
 


### PR DESCRIPTION
Fixes the following python 3 compat warnings when we run nose tests with **python -3**:
- /src/nose/nose/pyversion.py:49: DeprecationWarning: Overriding __eq__ blocks inheritance of __hash__ in 3.x
- /src/nose/unit_tests/mock.py:95: DeprecationWarning: dict.has_key() not supported in 3.x; use the in operator

Here there's also a suggestion to set __hash__ = None if we're sure instances will never be hashed: http://stackoverflow.com/questions/15471333/how-to-eliminate-a-python3-deprecation-warning-for-the-equality-operator.
