### PR TITLE
Allow importing tests from __init__.py files

### DIFF
--- a/nose/importer.py
+++ b/nose/importer.py
@@ -39,8 +39,6 @@ class Importer(object):
         # find the base dir of the package
         path_parts = os.path.normpath(os.path.abspath(path)).split(os.sep)
         name_parts = fqname.split('.')
-        if path_parts[-1] == '__init__.py':
-            path_parts.pop()
         path_parts = path_parts[:-(len(name_parts))]
         dir_path = os.sep.join(path_parts)
         # then import fqname starting from that dir


### PR DESCRIPTION
This allows running tests from `__init__.py` files specifically, e.g.

```
nosetests tests.__init__
```

This is not equivalent to running

```
nosetests tests
```

which would run all other files in that folder and subfolders as well.

I have to admit I don't fully understand why this code that I removed was there, so please let me know if this breaks something that I'm not aware of!
