### PR TITLE
Fix runmodule function to return the test result.

### DIFF
--- a/nose/core.py
+++ b/nose/core.py
@@ -306,7 +306,7 @@ def runmodule(name='__main__', **kw):
     tests in __main__. Additional arguments to TestProgram may be passed
     as keyword arguments.
     """
-    main(defaultTest=name, **kw)
+    return main(defaultTest=name, **kw)
 
 
 def collector():


### PR DESCRIPTION
This PR changes `runmodule` function to return the result value.

Currently, `runmodule` function returns `None`. This would have the following problems:
- Inconsistency with `main` function and `TestProgram`.
- Impossible to use the result of tests if it succeeded or failed.

To solve these problems, this PR changes `runmodule` 's return value.
