### PR TITLE
Explicitly set `__hash__` to `None` in cmp_to_key.Key

### DIFF
--- a/nose/pyversion.py
+++ b/nose/pyversion.py
@@ -55,6 +55,7 @@ def cmp_to_key(mycmp):
             return mycmp(self.obj, other.obj) > 0
         def __eq__(self, other):
             return mycmp(self.obj, other.obj) == 0
+        __hash__ = None
     return Key
 
 # Python 2.3 also does not support list-sorting by key, so we need to convert


### PR DESCRIPTION
See https://github.com/PyCQA/pylint/pull/1115 or https://github.com/nedbat/coveragepy/pull/17 for
an explanation for more discussion.
