### PR TITLE
Catch TypeError on import

### DIFF
--- a/nose/plugins/manager.py
+++ b/nose/plugins/manager.py
@@ -419,7 +419,7 @@ try:
     class DefaultPluginManager(BuiltinPluginManager, EntryPointPluginManager):
         pass
 
-except ImportError:
+except ImportError, AttributeError:
     class DefaultPluginManager(BuiltinPluginManager):
         pass
 

--- a/nose/plugins/plugintest.py
+++ b/nose/plugins/plugintest.py
@@ -173,7 +173,7 @@ class MultiProcessFile(object):
 try:
     from multiprocessing import Manager
     Buffer = MultiProcessFile
-except ImportError:
+except (ImportError, TypeError):
     Buffer = StringIO
 
 class PluginTester(object):

--- a/nose/plugins/plugintest.py
+++ b/nose/plugins/plugintest.py
@@ -106,7 +106,14 @@ except ImportError:
 
 __all__ = ['PluginTester', 'run']
 
-from os import getpid
+try:
+    from os import getpid
+    # if we fail to import getpid, just return a 'static' ineger
+except ImportError:
+    import random
+    def getpid(rv=[random.randint(0, 9999999),]):
+        return rv[0]
+
 class MultiProcessFile(object):
     """
     helper for testing multiprocessing
@@ -173,6 +180,7 @@ class MultiProcessFile(object):
 try:
     from multiprocessing import Manager
     Buffer = MultiProcessFile
+    # IronPython raises a TypeError trying to import multiprocessing
 except (ImportError, TypeError):
     Buffer = StringIO
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-VERSION = '1.3.7'
+VERSION = '1.3.7-dl'
 py_vers_tag = '-%s.%s' % sys.version_info[:2]
 
 test_dirs = ['functional_tests', 'unit_tests', os.path.join('doc','doc_tests'), 'nose']


### PR DESCRIPTION
Catch TypeError when checking import as well as ImportError.   TypeError is thrownwhen using IronPython 2.7.6.3.
