### PR TITLE
Fix doc broken links

### DIFF
--- a/doc/plugins/other.rst
+++ b/doc/plugins/other.rst
@@ -1,6 +1,0 @@
-Third-party nose plugins
-------------------------
-
-Visit http://nose-plugins.jottit.com/ for a list of third-party nose plugins
-compatible with nose 0.9 through 0.11. If you have released a plugin that you
-don't see in the list, please add it!

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -37,8 +37,7 @@ scheme, or it doesn't suit the layout of your project, or you need reports in
 a format different from the unittest standard, or you need to collect some
 additional information about tests (like code coverage or profiling data), you
 can write a plugin to make nose do what you want. See the section on
-:doc:`plugins/writing` for more.  There are also many 
-`third-party nose plugins <http://nose-plugins.jottit.com/>`_ available.
+:doc:`plugins/writing` for more.
 
 Details
 -------
@@ -51,5 +50,4 @@ Details
    finding_tests
    testing_tools
    plugins/builtin
-   plugins/other
    setuptools_integration

--- a/nose/plugins/__init__.py
+++ b/nose/plugins/__init__.py
@@ -176,8 +176,8 @@ See any builtin plugin or example plugin in the examples_ directory in
 the nose source distribution. There is a list of third-party plugins
 `on jottit`_.
 
-.. _examples/html_plugin/htmlplug.py: http://python-nose.googlecode.com/svn/trunk/examples/html_plugin/htmlplug.py
-.. _examples: http://python-nose.googlecode.com/svn/trunk/examples
+.. _examples/html_plugin/htmlplug.py: https://github.com/nose-devs/nose/blob/master/examples/html_plugin/htmlplug.py
+.. _examples: https://github.com/nose-devs/nose/tree/master/examples
 .. _on jottit: http://nose-plugins.jottit.com/
 
 """

--- a/nose/plugins/__init__.py
+++ b/nose/plugins/__init__.py
@@ -173,12 +173,10 @@ More Examples
 =============
 
 See any builtin plugin or example plugin in the examples_ directory in
-the nose source distribution. There is a list of third-party plugins
-`on jottit`_.
+the nose source distribution.
 
 .. _examples/html_plugin/htmlplug.py: https://github.com/nose-devs/nose/blob/master/examples/html_plugin/htmlplug.py
 .. _examples: https://github.com/nose-devs/nose/tree/master/examples
-.. _on jottit: http://nose-plugins.jottit.com/
 
 """
 from nose.plugins.base import Plugin


### PR DESCRIPTION
Found those broken links when reading the docs. The googlecode ones seemed straightforward enough. About jottit, I do not know this service, and maybe it's just a temporary failure. If you think so, feel free to drop the second commit.