### PR TITLE
DOC: rm outdated comment about `coverage.py` containing a nose plugin.

### DIFF
--- a/doc/plugins/cover.rst
+++ b/doc/plugins/cover.rst
@@ -3,12 +3,6 @@ Cover: code coverage
 
 .. note ::
 
-   Newer versions of coverage contain their own nose plugin which is
-   superior to the builtin plugin. It exposes more of coverage's
-   options and uses coverage's native html output. Depending on the
-   version of coverage installed, the included plugin may override the
-   nose builtin plugin, or be available under a different name. Check
-   ``nosetests --help`` or ``nosetests --plugins`` to find out which
-   coverage plugin is available on your system.
+   ``nose`` Contains a plugin for the ``coverage.py`` package.
 
 .. autoplugin :: nose.plugins.cover


### PR DESCRIPTION
This was never the case, as noted in https://github.com/nose-devs/nose/issues/1022#issuecomment-260150697.