### PR TITLE
doc: pre-format --nologcapture with double backquote

### DIFF
--- a/nose/plugins/logcapture.py
+++ b/nose/plugins/logcapture.py
@@ -98,7 +98,7 @@ class MyMemoryHandler(Handler):
 
 class LogCapture(Plugin):
     """
-    Log capture plugin. Enabled by default. Disable with --nologcapture.
+    Log capture plugin. Enabled by default. Disable with ``--nologcapture``.
     This plugin captures logging statements issued during test execution,
     appending any output captured to the error or failure output,
     should the test fail or raise an error.


### PR DESCRIPTION
Besides indicating `--nologcapture` as a command line option, prevent the double dashes (`--`) from being converted into EN DASH (`–`).

This same, file – `nose/plugins/logcapture.py` – has one line with trailing space. I'm happy adding a commit that amends this as well, but what are the guidelines about fixing one particular PEP8 violation on a specific file?

Thanks!