### PR TITLE
Fix compatibility with Python 3.6

### DIFF
--- a/functional_tests/test_loader.py
+++ b/functional_tests/test_loader.py
@@ -372,7 +372,7 @@ class TestNoseTestLoader(unittest.TestCase):
         assert res.errors, "Expected errors but got none"
         assert not res.failures, res.failures
         err = res.errors[0][0].test.exc_class
-        assert err is ImportError, \
+        assert issubclass(err, ImportError), \
             "Expected import error, got %s" % err
 
     def test_load_nonsense_name(self):

--- a/functional_tests/test_withid_failures.rst
+++ b/functional_tests/test_withid_failures.rst
@@ -7,16 +7,16 @@
     >>> support = os.path.join(os.path.dirname(__file__), 'support', 'id_fails')
     >>> argv = [__file__, '-v', '--with-id', '--id-file', idfile, support]
     >>> run(argv=argv, plugins=[TestId()]) # doctest: +ELLIPSIS
-    #1 Failure: ImportError (No module ...apackagethatdoesntexist...) ... ERROR
+    #1 Failure: ... (No module ...apackagethatdoesntexist...) ... ERROR
     #2 test_b.test ... ok
     #3 test_b.test_fail ... FAIL
     <BLANKLINE>
     ======================================================================
-    ERROR: Failure: ImportError (No module ...apackagethatdoesntexist...)
+    ERROR: Failure: ... (No module ...apackagethatdoesntexist...)
     ----------------------------------------------------------------------
     Traceback (most recent call last):
     ...
-    ImportError: No module ...apackagethatdoesntexist...
+    ...: No module ...apackagethatdoesntexist...
     <BLANKLINE>
     ======================================================================
     FAIL: test_b.test_fail
@@ -35,14 +35,14 @@ Addressing failures works (sometimes).
     >>> argv.append('1')
     >>> _junk = sys.modules.pop('test_a', None) # 2.3 requires
     >>> run(argv=argv, plugins=[TestId()]) #doctest: +ELLIPSIS
-    #1 Failure: ImportError (No module ...apackagethatdoesntexist...) ... ERROR
+    #1 Failure: ... (No module ...apackagethatdoesntexist...) ... ERROR
     <BLANKLINE>
     ======================================================================
-    ERROR: Failure: ImportError (No module ...apackagethatdoesntexist...)
+    ERROR: Failure: ... (No module ...apackagethatdoesntexist...)
     ----------------------------------------------------------------------
     Traceback (most recent call last):
     ...
-    ImportError: No module ...apackagethatdoesntexist...
+    ...: No module ...apackagethatdoesntexist...
     <BLANKLINE>
     ----------------------------------------------------------------------
     Ran 1 test in ...s


### PR DESCRIPTION
Python 3.6 returns ModuleNotFoundError instead of the previous ImportError.