### PR TITLE
Make Config's docstring raw

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -139,7 +139,7 @@ class ConfiguredDefaultsOptionParser(object):
 
 
 class Config(object):
-    """nose configuration.
+    r"""nose configuration.
 
     Instances of Config are used throughout nose to configure
     behavior, including plugin lists. Here are the default values for


### PR DESCRIPTION
The docstring contains escape sequences (`\b`, `\.`) in regular expressions that should not be interpreted by the Python lexer.