### PR TITLE
Ouput test names in the same format that Nose accepts as input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ python:
   - pypy
 install:
   - pip uninstall -y nose
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
 script:
   - python setup.py build_tests || python setup.py egg_info; python selftest.py

--- a/functional_tests/doc_tests/test_issue145/imported_tests.rst
+++ b/functional_tests/doc_tests/test_issue145/imported_tests.rst
@@ -42,11 +42,11 @@ imported, not the source modules.
     >>> argv = [__file__, '-v', support]
     >>> run(argv=argv) # doctest: +REPORT_NDIFF
     package1 setup
-    test (package1.test_module.TestCase) ... ok
+    test (package1.test_module:TestCase.test) ... ok
     package1.test_module.TestClass.test_class ... ok
     package1.test_module.test_function ... ok
     package2c setup
-    test (package2c.test_module.TestCase) ... ok
+    test (package2c.test_module:TestCase.test) ... ok
     package2c.test_module.TestClass.test_class ... ok
     package2f setup
     package2f.test_module.test_function ... ok
@@ -71,7 +71,7 @@ packages are executed.
     >>> argv = [__file__, '-v', os.path.join(support, 'package2c')]
     >>> run(argv=argv) # doctest: +REPORT_NDIFF
     package2c setup
-    test (package2c.test_module.TestCase) ... ok
+    test (package2c.test_module:TestCase.test) ... ok
     package2c.test_module.TestClass.test_class ... ok
     <BLANKLINE>
     ----------------------------------------------------------------------
@@ -98,7 +98,7 @@ command-line.
     ...         ':TestCase.test']
     >>> run(argv=argv) # doctest: +REPORT_NDIFF
     package2c setup
-    test (package2c.test_module.TestCase) ... ok
+    test (package2c.test_module:TestCase.test) ... ok
     <BLANKLINE>
     ----------------------------------------------------------------------
     Ran 1 test in ...s

--- a/functional_tests/doc_tests/test_selector_plugin/selector_plugin.rst
+++ b/functional_tests/doc_tests/test_selector_plugin/selector_plugin.rst
@@ -108,10 +108,10 @@ Now we can execute a test run using the custom selector, and the
 project's tests will be collected.
 
     >>> run(argv=argv, plugins=[UseMySelector()])
-    test_add (basic.TestBasicMath) ... ok
-    test_sub (basic.TestBasicMath) ... ok
-    test_tuple_groups (my_function.MyFunction) ... ok
-    test_cat (cat.StringsCat) ... ok
+    test_add (basic:TestBasicMath.test_add) ... ok
+    test_sub (basic:TestBasicMath.test_sub) ... ok
+    test_tuple_groups (my_function:MyFunction.test_tuple_groups) ... ok
+    test_cat (cat:StringsCat.test_cat) ... ok
     <BLANKLINE>
     ----------------------------------------------------------------------
     Ran 4 tests in ...s

--- a/functional_tests/test_attribute_plugin.py
+++ b/functional_tests/test_attribute_plugin.py
@@ -150,7 +150,7 @@ class TestClassAndMethodAttrs(AttributePluginTester):
     args = ["-a", "meth_attr=method,cls_attr=class"]
 
     def verify(self):
-        assert '(test_attr.TestClassAndMethodAttrs) ... ok' in self.output
+        assert '(test_attr:TestClassAndMethodAttrs.test_method) ... ok' in self.output
         assert 'test_case_two' not in self.output
         assert 'test_case_one' not in self.output
         assert 'test_case_three' not in self.output
@@ -166,7 +166,7 @@ class TestTopLevelNotSelected(AttributePluginTester):
         # rather than the attribute plugin, but the issue more easily manifests
         # itself when using attributes.
         assert 'test.test_b ... ok' in self.output
-        assert 'test_a (test.TestBase) ... ok' in self.output
+        assert 'test_a (test:TestBase.test_a) ... ok' in self.output
         assert 'TestDerived' not in self.output
 
 

--- a/functional_tests/test_load_tests_from_test_case.py
+++ b/functional_tests/test_load_tests_from_test_case.py
@@ -45,8 +45,8 @@ class TestLoadTestsFromTestCaseHook(PluginTester, unittest.TestCase):
 
     def runTest(self):
         expect = [
-            'test_value (%s.Derived) ... ERROR' % __name__,
-            'test_value (tests.Tests) ... ok']
+            'test_value (%s:Derived.test_value) ... ERROR' % __name__,
+            'test_value (tests:Tests.test_value) ... ok']
         print str(self.output)
         for line in self.output:
             if expect:

--- a/functional_tests/test_xunit.py
+++ b/functional_tests/test_xunit.py
@@ -25,7 +25,7 @@ class TestXUnitPlugin(PluginTester, unittest.TestCase):
         
         assert "ERROR: test_error" in self.output
         assert "FAIL: test_fail" in self.output
-        assert "test_skip (test_xunit_as_suite.TestForXunit) ... SKIP: skipit" in self.output
+        assert "test_skip (test_xunit_as_suite:TestForXunit.test_skip) ... SKIP: skipit" in self.output
         assert "XML: %s" % xml_results_filename in self.output
         
         f = codecs.open(xml_results_filename,'r', encoding='utf8')

--- a/nose/loader.py
+++ b/nose/loader.py
@@ -24,7 +24,7 @@ from nose.util import func_lineno, getpackage, isclass, isgenerator, \
     ispackage, regex_last_key, resolve_name, src, transplant_func, \
     transplant_class, test_address
 from nose.suite import ContextSuiteFactory, ContextList, LazySuite
-from nose.pyversion import sort_list, cmp_to_key
+from nose.pyversion import sort_list, cmp_to_key, new_str
 
 
 log = logging.getLogger(__name__)
@@ -569,6 +569,7 @@ class TestLoader(unittest.TestLoader):
             if parent and obj.__module__ != parent.__name__:
                 obj = transplant_class(obj, parent.__name__)
             if issubclass(obj, unittest.TestCase):
+                obj.__str__ = new_str
                 return self.loadTestsFromTestCase(obj)
             else:
                 return self.loadTestsFromTestClass(obj)
@@ -576,6 +577,7 @@ class TestLoader(unittest.TestLoader):
             if parent is None:
                 parent = obj.__class__
             if issubclass(parent, unittest.TestCase):
+                parent.__str__ = new_str
                 return parent(obj.__name__)
             else:
                 if isgenerator(obj):

--- a/nose/pyversion.py
+++ b/nose/pyversion.py
@@ -213,3 +213,24 @@ def format_exception(exc_info, encoding='UTF-8'):
         return force_unicode(
                 ''.join(traceback.format_exception(*exc_info)),
                 encoding)
+
+if sys.version_info >= (3, 3):
+    def new_str(test):
+        test_class = test.__class__
+        method_name = test._testMethodName
+        return "%s (%s:%s.%s)" % (
+            method_name,
+            test_class.__module__,
+            test_class.__qualname__,
+            method_name,
+        )
+else:
+    def new_str(test):
+        test_class = test.__class__
+        method_name = test._testMethodName
+        return "%s (%s:%s.%s)" % (
+            method_name,
+            test_class.__module__,
+            test_class.__name__,
+            method_name,
+        )


### PR DESCRIPTION
I restructured the way test data is output in verbose mode for easier everyday use of `nose`.

Test names are now printed in the same format that Nose takes as input. For example:

```
$ nosetests -v Test_1.mock_tests:MockTests 
test_print (Test_1.mock_tests.MockTests) ... ok
test_print_again (Test_1.mock_tests.MockTests) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.001s

OK
```

Compare this with how Nose currently presents the data,
```
$ nosetests -v Test_1.mock_tests:MockTests
test_print (Test_1.mock_tests:MockTests.test_print) ... ok
test_print_again (Test_1.mock_tests:MockTests.test_print_again) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.001s

OK
```

The difference is in the colon and printing the test function twice. **`Test_1.mock_tests:MockTests.test_print`** vs **`Test_1.mock_tests.MockTests`**

It might not look like much, but it makes a huge difference when copy-pasting into nosetest to re-run specific failing tests. The current output requires me to to transform the data manually when working.

This saves huge amounts of time and increases the usability of nose.