### PR TITLE
Replace logging.exception with logging.error

### DIFF
--- a/nose/plugins/multiprocess.py
+++ b/nose/plugins/multiprocess.py
@@ -697,7 +697,7 @@ def __runner(ix, testQueue, resultQueue, currentaddr, currentstart,
             errorClasses)
     for test_addr, arg in iter(get, 'STOP'):
         if shouldStop.is_set():
-            log.exception('Worker %d STOPPED',ix)
+            log.error('Worker %d STOPPED',ix)
             break
         result = makeResult()
         loader = loaderClass(config=config)


### PR DESCRIPTION
When I used `nosetests` command with `--stop` option, I failed to run my test, and it raises an exception.
And, I found that `logging.exception` must be called from only `except` clause. So I replaced it with `logging.error`.
https://docs.python.org/2/library/logging.html#logging.Logger.exception

I used python 3.4.5 and nose 1.3.7. You can easily reproduce the same problem with three test case sources which always fail and run `nosetests --processes=2 --stop`.