### PR TITLE
nose.plugins.collect: report failures when results have failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ python:
   - pypy
 install:
   - pip uninstall -y nose
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
 script:
   - python setup.py build_tests || python setup.py egg_info; python selftest.py

--- a/nose/plugins/collect.py
+++ b/nose/plugins/collect.py
@@ -1,6 +1,6 @@
 """
 This plugin bypasses the actual execution of tests, and instead just collects
-test names. Fixtures are also bypassed, so running nosetests with the 
+test names. Fixtures are also bypassed, so running nosetests with the
 collection plugin enabled should be very quick.
 
 This plugin is useful in combination with the testid plugin (``--with-id``).
@@ -12,6 +12,7 @@ people watching your demo think all of your tests pass.
 """
 from nose.plugins.base import Plugin
 from nose.case import Test
+from nose.failure import Failure
 import logging
 import unittest
 
@@ -54,8 +55,13 @@ class CollectOnly(Plugin):
             # a result proxy, due to using a stripped-down test suite
             self.conf.plugins.startTest(test)
             result.startTest(test)
-            self.conf.plugins.addSuccess(test)
-            result.addSuccess(test)
+            if test.context is Failure:
+                error = (test.test.exc_class, test.test.exc_val, test.test.tb)
+                self.conf.plugins.addFailure(test, err=error)
+                result.addFailure(test, err=error)
+            else:
+                self.conf.plugins.addSuccess(test)
+                result.addSuccess(test)
             self.conf.plugins.stopTest(test)
             result.stopTest(test)
         return run


### PR DESCRIPTION
For context: I use nose's collect plugin in my deployment system to figure out what tests are present in a large code. Master does this and then it farms the tasks to workers. The workers then just run nosetests on each task. Sometimes, a deployment revision might have bugs at import time and then tests collected are incorrect and the failures are not easy to determine because there are no tracebacks. 