### PR TITLE
Clarify ignore-files help string

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -529,8 +529,8 @@ class Config(object):
         parser.add_option(
             "-I", "--ignore-files", action="append", dest="ignoreFiles",
             metavar="REGEX",
-            help="Completely ignore any file that matches this regular "
-            "expression. Takes precedence over any other settings or "
+            help="Completely ignore any file with a basename matching this "
+            "regular expression. Takes precedence over any other settings or "
             "plugins. "
             "Specifying this option will replace the default setting. "
             "Specify this option multiple times "


### PR DESCRIPTION
It isn't immediately clear that this option only checks the basename of
the file, rather than the entire path - make it a bit clearer in the
help message so that people don't end up digging through the code to
find this out.