### PR TITLE
Add nosetests3 to console_scripts for Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ python:
   - pypy
 install:
   - pip uninstall -y nose
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
 script:
   - python setup.py build_tests || python setup.py egg_info; python selftest.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ python:
   - pypy
 install:
   - pip uninstall -y nose
-  - pip install -r requirements.txt
+  - pip install -r requirements.txt --use-mirrors
 script:
   - python setup.py build_tests || python setup.py egg_info; python selftest.py

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ try:
         },
         test_suite = 'nose.collector',
         )
+    if sys.version_info[0] == 3:
+         addl_args['entry_points']['console_scripts'].append('nosetests3 = nose:run_exit')
     addl_args.update(extra)
 
     # This is required by multiprocess plugin; on Windows, if


### PR DESCRIPTION
Using generic nosetests3 instead of minor-version oriented pattern is
more compatible for packages that use nosetests. Apart from increased
compatibility coverage, I recently noticed few packages that uses
nosetests3 in their tests. Sounds like it should be fixed at this level.