### PR TITLE
Fixes Issue #1086

### DIFF
--- a/nose/selector.py
+++ b/nose/selector.py
@@ -7,6 +7,7 @@ appropriate selector method for each object it encounters that it
 thinks may be a test.
 """
 import logging
+import stat
 import os
 import unittest
 from nose.config import Config
@@ -123,6 +124,11 @@ class Selector(object):
         if not self.config.includeExe and is_executable(file):
             log.info('%s is executable; skipped', file)
             return False
+
+        if os.path.exists(file) and not stat.S_ISREG((os.stat(file)).st_mode):
+            log.info('%s is not a regular file; skipped', file)
+            return False
+
         dummy, ext = op_splitext(base)
         pysrc = ext == '.py'
 

--- a/unit_tests/test_selector.py
+++ b/unit_tests/test_selector.py
@@ -133,6 +133,8 @@ class TestSelector(unittest.TestCase):
         assert not s.wantFile('test_data.txt')
         assert not s.wantFile('data.text')
         assert not s.wantFile('bar/baz/__init__.py')
+
+        assert not s.wantFile('fifo.py')
         
     def test_want_function(self):
         def foo():


### PR DESCRIPTION
This pr checks that any encountered '.py' file is a regular file to address #1086. This ensures that nose will skip any fifo/device/etc that is named with the '.py' extension.