### PR TITLE
Fix exception causes in util.py

### DIFF
--- a/nose/util.py
+++ b/nose/util.py
@@ -355,7 +355,7 @@ def split_test_name(test):
             if file_like(fn):
                 # must be a funny path
                 file_or_mod, fn = test, None
-        except ValueError:
+        except ValueError as e:
             # more than one : in the test
             # this is a case like c:\some\path.py:a_test
             parts = test.split(':')
@@ -365,7 +365,7 @@ def split_test_name(test):
                 # nonsense like foo:bar:baz
                 raise ValueError("Test name '%s' could not be parsed. Please "
                                  "format test names as path:callable or "
-                                 "module:callable." % (test,))
+                                 "module:callable." % (test,)) from e
     elif not tail:
         # this is a case like 'foo:bar/'
         # : must be part of the file path, so ignore it
@@ -459,11 +459,11 @@ def try_run(obj, names):
                         args, varargs, varkw, defaults = \
                             inspect.getargspec(func)
                         args.pop(0) # pop the self off
-                    except TypeError:
+                    except TypeError as e:
                         raise TypeError("Attribute %s of %r is not a python "
                                         "function. Only functions or callables"
                                         " may be used as fixtures." %
-                                        (name, obj))
+                                        (name, obj)) from e
                 if len(args):
                     log.debug("call fixture %s.%s(%s)", obj, name, obj)
                     return func(obj)


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 