### PR TITLE
Fix bare except clauses with specific exception types in plugins/manager.py

### DIFF
--- a/nose/plugins/manager.py
+++ b/nose/plugins/manager.py
@@ -61,11 +61,11 @@ from nose.pyversion import sort_list
 
 try:
     import cPickle as pickle
-except:
+except ImportError:
     import pickle
 try:
     from cStringIO import StringIO
-except:
+except ImportError:
     from StringIO import StringIO
 
 
@@ -155,7 +155,7 @@ class PluginProxy(object):
                         yield r
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except:
+            except Exception:
                 exc = sys.exc_info()
                 yield Failure(*exc)
                 continue


### PR DESCRIPTION
Replace bare `except:` clauses with specific exception types in `nose/plugins/manager.py`.

- Lines 64, 68: `except:` → `except ImportError:` for Python 2/3 compatibility imports (`cPickle`, `cStringIO`)
- Line 158: `except:` → `except Exception:` for plugin iteration errors (after explicit `KeyboardInterrupt`/`SystemExit` handler)

Bare `except:` clauses catch `BaseException` including `SystemExit` and `KeyboardInterrupt`, which can interfere with normal process termination.